### PR TITLE
Disable tenant popup

### DIFF
--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -96,7 +96,7 @@ export async function setupTopNavButton(coreStart: CoreStart, config: ClientConf
       }
     }
 
-    setShouldShowTenantPopup(shouldShowTenantPopup);
+    setShouldShowTenantPopup(false);
 
     coreStart.chrome.navControls.registerRight({
       // Pin to rightmost, since newsfeed plugin is using 1000, here needs a number > 1000

--- a/public/apps/account/test/account-app.test.tsx
+++ b/public/apps/account/test/account-app.test.tsx
@@ -105,14 +105,14 @@ describe('Account app', () => {
     });
   });
 
-  it('Should show tenant selection popup when neither securitytenant in url nor saved tenant', (done) => {
+  it('Should not show tenant selection popup', (done) => {
     (getSavedTenant as jest.Mock).mockReturnValueOnce(null);
 
     setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
       expect(getSavedTenant).toBeCalledTimes(1);
-      expect(setShouldShowTenantPopup).toBeCalledWith(true);
+      expect(setShouldShowTenantPopup).toBeCalledWith(false);
       done();
     });
   });


### PR DESCRIPTION
### Description
The following list of changes have been applied:

- Disable first time pop-up tenant selector.

### Issues Resolved
- #11 

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).