### PR TITLE
Add GitHub workflow for automated build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+# This workflow builds a production-ready package when a tag is created.
+#
+# This workflow is based on the `dev-environment` workflow.
+
+name: Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    name: Build app package (auto)
+    uses: ./.github/workflows/dev-environment.yml
+    with:
+      reference: ${{ github.ref_name }}
+      command: 'yarn build'
+      artifact_name: 'wazuh-security-dashboards-plugin-${{ github.ref_name }}'
+      artifact_path: './wazuh-security-plugin/build'

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -1,0 +1,92 @@
+# This workflow downloads the source code at the given git reference
+# (branch, tag or commit), an sets up an environment (Kibana or OpenSearch)
+# to run this code and a command (build, test, ...).
+#
+# This workflow is used as a base for other workflows.
+
+name: Base workflow - Environment
+
+on:
+  workflow_call:
+    inputs:
+      reference:
+        required: true
+        type: string
+        default: master
+        description: Source code reference (branch, tag or commit SHA).
+      command:
+        required: true
+        type: string
+        default: 'yarn build'
+        description: Command to run in the environment
+      docker_run_extra_args:
+        type: string
+        default: ''
+        description: Additional paramaters for the docker run command.
+        required: false
+      artifact_name:
+        type: string
+        default: ''
+        description: Artifact name (will be automatically suffixed with .zip)
+        required: false
+      artifact_path:
+        type: string
+        default: ''
+        description: Folder to include in the archive.
+        required: false
+      notify_jest_coverage_summary:
+        type: boolean
+        default: false
+        required: false
+
+jobs:
+  # Deploy the plugin in a development environment and run a command
+  # using a pre-built Docker image, hosted in Quay.io.
+  deploy_and_run_command:
+    name: Deploy and run command
+    runs-on: ubuntu-latest
+    steps:
+      - name: Step 01 - Download the plugin's source code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
+          path: wazuh-security-plugin
+
+      # Fix source code ownership so the internal user of the Docker
+      # container is also owner.
+      - name: Step 02 - Change code ownership
+        run: sudo chown 1000:1000 -R wazuh-security-plugin;
+
+      - name: Step 03 - Set up the environment and run the command
+        run: |
+          # Read the platform version from the package.json file
+          echo "Reading the platform version from the package.json...";
+          # Support plugins whose version is defined under pluginPlatform or Kibana properties
+          platform_version=$(jq -r '.opensearchDashboards.version | select(. != null)' wazuh-security-plugin/package.json);
+          echo "Plugin platform version: $platform_version";
+
+          # Up the environment and run the command
+          docker run -t --rm \
+            -e OPENSEARCH_DASHBOARDS_VERSION=${platform_version} \
+            -v `pwd`/wazuh-security-plugin:/home/node/kbn/plugins/wazuh-security-plugin \
+            ${{ inputs.docker_run_extra_args }} \
+            quay.io/wazuh/osd-dev:${platform_version} \
+            bash -c '
+              yarn config set registry https://registry.yarnpkg.com;
+              cd /home/node/kbn/plugins/wazuh-security-plugin && yarn && ${{ inputs.command }};
+            '
+
+      - name: Step 04 - Upload artifact to GitHub
+        if: ${{ inputs.artifact_name && inputs.artifact_path }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_path }}
+
+      - name: Step 05 - Upload coverage results to GitHub
+        if: ${{ inputs.notify_jest_coverage_summary && github.event_name == 'pull_request' }}
+        uses: AthleticNet/comment-test-coverage@1.2.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./wazuh-security-plugin/target/test-coverage/coverage-summary.json
+          title: "Code coverage (Jest)"

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           # Read the platform version from the package.json file
           echo "Reading the platform version from the package.json...";
-          # Support plugins whose version is defined under pluginPlatform or Kibana properties
           platform_version=$(jq -r '.opensearchDashboards.version | select(. != null)' wazuh-security-plugin/package.json);
           echo "Plugin platform version: $platform_version";
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,27 @@
+# This workflow builds a production-ready package from the given Git reference.
+# Any branch, tag or commit SHA existing in the origin can be used.
+#
+# This workflow is based on the `dev-environment` workflow.
+
+name: Manual build
+
+on:
+  workflow_dispatch:
+    inputs:
+      reference:
+        required: true
+        type: string
+        default: master
+        description: Source code reference (branch, tag or commit SHA)
+
+jobs:
+  # Build an app package from the given source code reference.
+  build:
+    name: Build app package
+    uses: ./.github/workflows/dev-environment.yml
+    with:
+      reference: ${{ github.event.inputs.reference }}
+      command: 'yarn build'
+      artifact_name: 'wazuh-security-dashboards-plugin-${{ github.event.inputs.reference }}.zip'
+      artifact_path: './wazuh-security-plugin/build'
+    secrets: inherit


### PR DESCRIPTION
### Description
You want to automate the creation of plugin packages to speed up the publishing process.

### Issues Resolved
- #14 

### Evidence

#### Build Manual

https://github.com/yenienserrano/wazuh-security-dashboards-plugin/actions/runs/4946505162

![image](https://github.com/wazuh/wazuh-security-dashboards-plugin/assets/63758389/183c3372-24e0-414d-a650-61e4990bb192)

#### Build for tag

https://github.com/yenienserrano/wazuh-security-dashboards-plugin/actions/runs/4946814606

![image](https://github.com/wazuh/wazuh-security-dashboards-plugin/assets/63758389/5d558e35-d967-4ab7-88d6-ac12ba28778d)

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).