### PR TITLE
Change order of security in left menu

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -100,7 +100,7 @@ export class SecurityPlugin
       core.application.register({
         id: PLUGIN_NAME,
         title: 'Security',
-        order: 9050,
+        order: 9030,
         mount: async (params: AppMountParameters) => {
           const { renderApp } = await import('./apps/configuration/configuration-app');
           const [coreStart, depsStart] = await core.getStartServices();
@@ -121,7 +121,7 @@ export class SecurityPlugin
         deps.managementOverview.register({
           id: PLUGIN_NAME,
           title: 'Security',
-          order: 9050,
+          order: 9030,
           description: i18n.translate('security.securityDescription', {
             defaultMessage:
               'Configure how users access data in OpenSearch with authentication, access control and audit logging.',


### PR DESCRIPTION
### Description
Change the order of security plugin in the left menu

### Issues Resolved

- https://github.com/wazuh/wazuh-dashboard/issues/140

### Screenshot

![image](https://github.com/wazuh/wazuh-security-dashboards-plugin/assets/63758389/5528d9ae-0cda-4df3-a1d1-e6ddcd6fd1b3)

### Testing

Build wazuh dashboard package with this plugin and check the left menu order

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).