### PR TITLE
Unzip command not found in package generation action

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -75,8 +75,9 @@ jobs:
               yarn config set registry https://registry.yarnpkg.com;
               cd /home/node/kbn/plugins/wazuh-security-plugin && yarn && ${{ inputs.command }};
             '
-      - name: Get the plugin version
+      - name: Get the plugin version and and format reference name
         run: |
+          echo "githubReference=$(echo ${{ inputs.reference }} | sed 's/\//-/g')" >> $GITHUB_ENV
           echo "version=$(jq -r '.wazuh.version' $(pwd)/wazuh-security-plugin/package.json)" >> $GITHUB_ENV
           echo "revision=$(jq -r '.wazuh.revision' $(pwd)/wazuh-security-plugin/package.json)" >> $GITHUB_ENV
 
@@ -84,7 +85,7 @@ jobs:
         if: ${{ inputs.artifact_name && inputs.artifact_path }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ inputs.reference }}.zip
+          name: ${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
           path: ${{ inputs.artifact_path }}
           overwrite: true
 
@@ -94,4 +95,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ./wazuh-security-plugin/target/test-coverage/coverage-summary.json
-          title: "Code coverage (Jest)"
+          title: 'Code coverage (Jest)'


### PR DESCRIPTION
### Description
This pull request fixes an error in the packages building workflow. It also adds logic to allow the workflow running in branches that contains `/`.

### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/430

### Evidence
- https://github.com/wazuh/wazuh-dashboard/actions/runs/12056050079

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).