### PR TITLE
Replace the SAML default embedded route redirects with a new default route redirect.

### DIFF
--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -118,8 +118,7 @@ export class SamlAuthRoutes {
           if (cookie) {
             requestId = cookie.saml?.requestId || '';
             nextUrl =
-              cookie.saml?.nextUrl ||
-              `${this.coreSetup.http.basePath.serverBasePath}/app/wz-home`;
+              cookie.saml?.nextUrl || `${this.coreSetup.http.basePath.serverBasePath}/app/wz-home`;
             redirectHash = cookie.saml?.redirectHash || false;
           }
           if (!requestId) {

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -71,7 +71,7 @@ export class SamlAuthRoutes {
         if (request.auth.isAuthenticated) {
           return response.redirected({
             headers: {
-              location: `${this.coreSetup.http.basePath.serverBasePath}/app/opensearch-dashboards`,
+              location: `${this.coreSetup.http.basePath.serverBasePath}/app/wz-home`,
             },
           });
         }
@@ -119,7 +119,7 @@ export class SamlAuthRoutes {
             requestId = cookie.saml?.requestId || '';
             nextUrl =
               cookie.saml?.nextUrl ||
-              `${this.coreSetup.http.basePath.serverBasePath}/app/opensearch-dashboards`;
+              `${this.coreSetup.http.basePath.serverBasePath}/app/wz-home`;
             redirectHash = cookie.saml?.redirectHash || false;
           }
           if (!requestId) {
@@ -251,7 +251,7 @@ export class SamlAuthRoutes {
           this.sessionStorageFactory.asScoped(request).set(cookie);
           return response.redirected({
             headers: {
-              location: `${this.coreSetup.http.basePath.serverBasePath}/app/opensearch-dashboards`,
+              location: `${this.coreSetup.http.basePath.serverBasePath}/app/wz-home`,
             },
           });
         } catch (error) {

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -61,7 +61,7 @@ export class SamlAuthentication extends AuthenticationType {
   private generateNextUrl(request: OpenSearchDashboardsRequest): string {
     let path =
       this.coreSetup.http.basePath.serverBasePath +
-      (request.url.pathname || '/app/opensearch-dashboards');
+      (request.url.pathname || '/app/wz-home');
     if (request.url.search) {
       path += request.url.search;
     }

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -60,8 +60,7 @@ export class SamlAuthentication extends AuthenticationType {
 
   private generateNextUrl(request: OpenSearchDashboardsRequest): string {
     let path =
-      this.coreSetup.http.basePath.serverBasePath +
-      (request.url.pathname || '/app/wz-home');
+      this.coreSetup.http.basePath.serverBasePath + (request.url.pathname || '/app/wz-home');
     if (request.url.search) {
       path += request.url.search;
     }

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -29,7 +29,7 @@ before(() => {
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
   // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.visit(`http://localhost:5601${basePath}`);
+  cy.visit(`http://localhost:7000${basePath}`);
 
   cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
   cy.clearCookies();
@@ -54,7 +54,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 
@@ -68,7 +68,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+    cy.visit(`http://localhost:7000${basePath}/app/dev_tools#/console`, {
       failOnStatusCode: false,
     });
 
@@ -82,7 +82,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
+    const urlWithHash = `http://localhost:7000${basePath}/app/security-dashboards-plugin#/getstarted`;
 
     cy.visit(urlWithHash, {
       failOnStatusCode: false,
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 
@@ -133,7 +133,7 @@ describe('Log in via SAML', () => {
       // We need to explicitly clear cookies,
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
-        const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
+        const gotoUrl = `http://localhost:7000${basePath}/goto/${response.urlId}?security_tenant=global`;
         cy.visit(gotoUrl);
         samlLogin();
         cy.getCookie('security_authentication').should('exist');

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -50,11 +50,11 @@ describe('Log in via SAML', () => {
     }
   };
 
-  it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
+  it('Login to app/wz-home_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 


### PR DESCRIPTION
### Description

Changes an embedded route redirect to `/app/wz-home` by default.

### Category

Bug


### Issues Resolved

- https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/170


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff
