### PR TITLE
Fix an error in GitHub action tests

### DIFF
--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -25,7 +25,7 @@ runs:
         mvn dependency:get \
         -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
-        -Dtransitive=false \
-        -Ddest=${{ inputs.download-location }}.zip
+        -Dtransitive=false
+        # Ddest flag is obsolete, to copy correctly "cp" is must be run like => (https://github.com/opensearch-project/security-dashboards-plugin/commit/90b2e773b30861bde0ef5e16ea8fe0713ddf5512)
+        cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-SNAPSHOT.zip ${{ inputs.download-location }}.zip
       shell: bash
-      

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -98,13 +98,6 @@ runs:
         done
       shell: bash
 
-    - name : Cat dashboard.log
-      run: |
-        cd ./OpenSearch-Dashboards
-        echo "cat dashboard.log"
-        cat ./dashboard.log
-      shell: bash
-
     - name: Run Cypress Tests with retry
       uses: Wandalen/wretry.action@v3
       with:

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -98,6 +98,13 @@ runs:
         done
       shell: bash
 
+    - name : Cat dashboard.log
+      run: |
+        cd ./OpenSearch-Dashboards
+        echo "cat dashboard.log"
+        cat ./dashboard.log
+      shell: bash
+
     - name: Run Cypress Tests with retry
       uses: Wandalen/wretry.action@v3
       with:

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -85,6 +85,4 @@ jobs:
           git clone https://github.com/opensearch-project/opensearch-dashboards-functional-test.git -b ${{ env.OPENSEARCH_VERSION }}
           cd opensearch-dashboards-functional-test
           npm install cypress --save-dev
-          find cypress -type f -name "inaccessible_tenancy_features.js"
-          ls cypress/integration/plugins/security
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/inaccessible_tenancy_features.js"
+          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/inaccessible_tenancy_features.js"

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -85,4 +85,6 @@ jobs:
           git clone https://github.com/opensearch-project/opensearch-dashboards-functional-test.git -b ${{ env.OPENSEARCH_VERSION }}
           cd opensearch-dashboards-functional-test
           npm install cypress --save-dev
+          find cypress -type f -name "inaccessible_tenancy_features.js"
+          ls cypress/integration/plugins/security
           yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/inaccessible_tenancy_features.js"

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -105,7 +105,6 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-
     cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
       cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
         failOnStatusCode: false,
@@ -147,7 +146,7 @@ describe('Log in via SAML', () => {
         cy.origin('http://localhost:7000', () => {
           cy.visit(gotoUrl);
         });
-        
+
         samlLogin();
         cy.getCookie('security_authentication').should('exist');
       });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -88,47 +88,51 @@ describe('Log in via SAML', () => {
 
     const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
 
-    cy.visit(urlWithHash, {
-      failOnStatusCode: false,
+    cy.origin('http://localhost:5601', () => {
+      cy.visit(urlWithHash, {
+        failOnStatusCode: false,
+      });
+
+      samlLogin();
+
+      cy.get('h1.euiTitle--large').contains('Get started');
+      cy.getCookie('security_authentication').should('exist');
     });
-
-    samlLogin();
-
-    cy.get('h1.euiTitle--large').contains('Get started');
-    cy.getCookie('security_authentication').should('exist');
   });
 
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
-      failOnStatusCode: false,
+    cy.origin('http://localhost:5601', () => {
+      cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
+        failOnStatusCode: false,
+      });
+
+      samlLogin();
+      cy.get('#user-icon-btn').should('be.visible');
+      cy.get('#user-icon-btn').click();
+      cy.get('button[data-test-subj^="switch-tenants"]').click();
+
+      cy.get('#private').should('be.enabled');
+      cy.get('#private').click({ force: true });
+
+      cy.get('button[data-test-subj="confirm"]').click();
+
+      cy.get('#osdOverviewPageHeader__title').should('be.visible');
+
+      cy.get('button[id="user-icon-btn"]').click();
+
+      cy.get('button[data-test-subj^="log-out-"]').click();
+
+      samlLogin();
+
+      cy.get('#user-icon-btn').should('be.visible');
+      cy.get('#user-icon-btn').click();
+
+      cy.get('#osdOverviewPageHeader__title').should('be.visible');
+
+      cy.get('#tenantName').should('have.text', 'Private');
     });
-
-    samlLogin();
-    cy.get('#user-icon-btn').should('be.visible');
-    cy.get('#user-icon-btn').click();
-    cy.get('button[data-test-subj^="switch-tenants"]').click();
-
-    cy.get('#private').should('be.enabled');
-    cy.get('#private').click({ force: true });
-
-    cy.get('button[data-test-subj="confirm"]').click();
-
-    cy.get('#osdOverviewPageHeader__title').should('be.visible');
-
-    cy.get('button[id="user-icon-btn"]').click();
-
-    cy.get('button[data-test-subj^="log-out-"]').click();
-
-    samlLogin();
-
-    cy.get('#user-icon-btn').should('be.visible');
-    cy.get('#user-icon-btn').click();
-
-    cy.get('#osdOverviewPageHeader__title').should('be.visible');
-
-    cy.get('#tenantName').should('have.text', 'Private');
   });
 
   it('Login to Dashboard with Goto URL', () => {
@@ -138,9 +142,11 @@ describe('Log in via SAML', () => {
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
         const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
-        cy.visit(gotoUrl);
-        samlLogin();
-        cy.getCookie('security_authentication').should('exist');
+        cy.origin('http://localhost:5601', () => {
+          cy.visit(gotoUrl);
+          samlLogin();
+          cy.getCookie('security_authentication').should('exist');
+        });
       });
     });
   });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -29,7 +29,7 @@ before(() => {
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
   // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.visit(`http://localhost:5601${basePath}`);
+  cy.visit(`http://localhost:7000${basePath}`);
 
   cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
   cy.clearCookies();
@@ -54,7 +54,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 
@@ -68,7 +68,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+    cy.visit(`http://localhost:7000${basePath}/app/dev_tools#/console`, {
       failOnStatusCode: false,
     });
 
@@ -82,7 +82,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
+    const urlWithHash = `http://localhost:7000${basePath}/app/security-dashboards-plugin#/getstarted`;
 
     cy.visit(urlWithHash, {
       failOnStatusCode: false,
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 
@@ -133,7 +133,7 @@ describe('Log in via SAML', () => {
       // We need to explicitly clear cookies,
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
-        const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
+        const gotoUrl = `http://localhost:7000${basePath}/goto/${response.urlId}?security_tenant=global`;
         cy.visit(gotoUrl);
         samlLogin();
         cy.getCookie('security_authentication').should('exist');

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -29,7 +29,9 @@ before(() => {
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
   // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.visit(`http://localhost:5601${basePath}`);
+  cy.origin('http://localhost:7000', () => {
+    cy.visit(`http://localhost:5601${basePath}`);
+  });
 
   cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
   cy.clearCookies();
@@ -58,7 +60,7 @@ describe('Log in via SAML', () => {
     } catch (error) {
       console.log(error);
     }
-    
+
     cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -53,19 +53,17 @@ describe('Log in via SAML', () => {
   };
 
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
-    localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
-    localStorage.setItem('home:newThemeModal:show', 'false');
-
     cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+      localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
+      localStorage.setItem('home:newThemeModal:show', 'false');
       cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
         failOnStatusCode: false,
       });
+      samlLogin();
+
+      cy.get('#osdOverviewPageHeader__title').should('be.visible');
+      cy.getCookie('security_authentication').should('exist');
     });
-
-    samlLogin();
-
-    cy.get('#osdOverviewPageHeader__title').should('be.visible');
-    cy.getCookie('security_authentication').should('exist');
   });
 
   it('Login to app/dev_tools#/console when SAML is enabled', () => {

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -50,11 +50,11 @@ describe('Log in via SAML', () => {
     }
   };
 
-  it('Login to app/wz-home#/ when SAML is enabled', () => {
+  it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
+    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });
 
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
+    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });
 

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -29,7 +29,7 @@ before(() => {
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
   // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.visit(`http://localhost:7000${basePath}`);
+  cy.visit(`http://localhost:5601${basePath}`);
 
   cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
   cy.clearCookies();
@@ -54,7 +54,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 
@@ -68,7 +68,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/dev_tools#/console`, {
+    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
       failOnStatusCode: false,
     });
 
@@ -82,7 +82,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    const urlWithHash = `http://localhost:7000${basePath}/app/security-dashboards-plugin#/getstarted`;
+    const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
 
     cy.visit(urlWithHash, {
       failOnStatusCode: false,
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home_overview`, {
       failOnStatusCode: false,
     });
 
@@ -133,7 +133,7 @@ describe('Log in via SAML', () => {
       // We need to explicitly clear cookies,
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
-        const gotoUrl = `http://localhost:7000${basePath}/goto/${response.urlId}?security_tenant=global`;
+        const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
         cy.visit(gotoUrl);
         samlLogin();
         cy.getCookie('security_authentication').should('exist');

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -29,13 +29,13 @@ before(() => {
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
   // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
-    cy.visit(`http://localhost:5601${basePath}`);
-  });
+  cy.visit(`http://localhost:5601${basePath}`);
 
-  cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
-  cy.clearCookies();
-  cy.clearLocalStorage();
+  cy.origin('http://localhost:7000', () => {
+    cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
+    cy.clearCookies();
+    cy.clearLocalStorage();
+  });
 });
 
 afterEach(() => {
@@ -53,32 +53,25 @@ describe('Log in via SAML', () => {
   };
 
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
-    cy.origin(
-      'http://localhost:7000',
-      { args: { basePath, samlLogin } },
-      ({ basePath, samlLogin }) => {
-        localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
-        localStorage.setItem('home:newThemeModal:show', 'false');
-        cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-          failOnStatusCode: false,
-        });
+    localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
+    localStorage.setItem('home:newThemeModal:show', 'false');
 
-        samlLogin();
+    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+      failOnStatusCode: false,
+    });
 
-        cy.get('#osdOverviewPageHeader__title').should('be.visible');
-        cy.getCookie('security_authentication').should('exist');
-      }
-    );
+    samlLogin();
+
+    cy.get('#osdOverviewPageHeader__title').should('be.visible');
+    cy.getCookie('security_authentication').should('exist');
   });
 
   it('Login to app/dev_tools#/console when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
-      cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
-        failOnStatusCode: false,
-      });
+    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+      failOnStatusCode: false,
     });
 
     samlLogin();
@@ -93,10 +86,8 @@ describe('Log in via SAML', () => {
 
     const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
 
-    cy.origin('http://localhost:7000', () => {
-      cy.visit(urlWithHash, {
-        failOnStatusCode: false,
-      });
+    cy.visit(urlWithHash, {
+      failOnStatusCode: false,
     });
 
     samlLogin();
@@ -108,10 +99,8 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
-      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-        failOnStatusCode: false,
-      });
+    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+      failOnStatusCode: false,
     });
 
     samlLogin();
@@ -146,10 +135,7 @@ describe('Log in via SAML', () => {
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
         const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
-        cy.origin('http://localhost:7000', () => {
-          cy.visit(gotoUrl);
-        });
-
+        cy.visit(gotoUrl);
         samlLogin();
         cy.getCookie('security_authentication').should('exist');
       });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -53,13 +53,15 @@ describe('Log in via SAML', () => {
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
-
+  
     cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });
-
-    samlLogin();
-
+  
+    cy.origin('http://localhost:7000', () => {
+      samlLogin();
+    });
+  
     cy.get('#osdOverviewPageHeader__title').should('be.visible');
     cy.getCookie('security_authentication').should('exist');
   });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -54,32 +54,28 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.origin('http://localhost:5601', () => {
-      cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
-        failOnStatusCode: false,
-      });
-
-      samlLogin();
-
-      cy.get('#osdOverviewPageHeader__title').should('be.visible');
-      cy.getCookie('security_authentication').should('exist');
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
+      failOnStatusCode: false,
     });
+
+    samlLogin();
+
+    cy.get('#osdOverviewPageHeader__title').should('be.visible');
+    cy.getCookie('security_authentication').should('exist');
   });
 
   it('Login to app/dev_tools#/console when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.origin('http://localhost:5601', () => {
-      cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
-        failOnStatusCode: false,
-      });
-
-      samlLogin();
-
-      cy.get('a.euiBreadcrumb--last').contains('Dev Tools');
-      cy.getCookie('security_authentication').should('exist');
+    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+      failOnStatusCode: false,
     });
+
+    samlLogin();
+
+    cy.get('a.euiBreadcrumb--last').contains('Dev Tools');
+    cy.getCookie('security_authentication').should('exist');
   });
 
   it('Login to Dashboard with Hash', () => {
@@ -88,51 +84,47 @@ describe('Log in via SAML', () => {
 
     const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
 
-    cy.origin('http://localhost:5601', () => {
-      cy.visit(urlWithHash, {
-        failOnStatusCode: false,
-      });
-
-      samlLogin();
-
-      cy.get('h1.euiTitle--large').contains('Get started');
-      cy.getCookie('security_authentication').should('exist');
+    cy.visit(urlWithHash, {
+      failOnStatusCode: false,
     });
+
+    samlLogin();
+
+    cy.get('h1.euiTitle--large').contains('Get started');
+    cy.getCookie('security_authentication').should('exist');
   });
 
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.origin('http://localhost:5601', () => {
-      cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
-        failOnStatusCode: false,
-      });
-
-      samlLogin();
-      cy.get('#user-icon-btn').should('be.visible');
-      cy.get('#user-icon-btn').click();
-      cy.get('button[data-test-subj^="switch-tenants"]').click();
-
-      cy.get('#private').should('be.enabled');
-      cy.get('#private').click({ force: true });
-
-      cy.get('button[data-test-subj="confirm"]').click();
-
-      cy.get('#osdOverviewPageHeader__title').should('be.visible');
-
-      cy.get('button[id="user-icon-btn"]').click();
-
-      cy.get('button[data-test-subj^="log-out-"]').click();
-
-      samlLogin();
-
-      cy.get('#user-icon-btn').should('be.visible');
-      cy.get('#user-icon-btn').click();
-
-      cy.get('#osdOverviewPageHeader__title').should('be.visible');
-
-      cy.get('#tenantName').should('have.text', 'Private');
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
+      failOnStatusCode: false,
     });
+
+    samlLogin();
+    cy.get('#user-icon-btn').should('be.visible');
+    cy.get('#user-icon-btn').click();
+    cy.get('button[data-test-subj^="switch-tenants"]').click();
+
+    cy.get('#private').should('be.enabled');
+    cy.get('#private').click({ force: true });
+
+    cy.get('button[data-test-subj="confirm"]').click();
+
+    cy.get('#osdOverviewPageHeader__title').should('be.visible');
+
+    cy.get('button[id="user-icon-btn"]').click();
+
+    cy.get('button[data-test-subj^="log-out-"]').click();
+
+    samlLogin();
+
+    cy.get('#user-icon-btn').should('be.visible');
+    cy.get('#user-icon-btn').click();
+
+    cy.get('#osdOverviewPageHeader__title').should('be.visible');
+
+    cy.get('#tenantName').should('have.text', 'Private');
   });
 
   it('Login to Dashboard with Goto URL', () => {
@@ -142,11 +134,9 @@ describe('Log in via SAML', () => {
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
         const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
-        cy.origin('http://localhost:5601', () => {
-          cy.visit(gotoUrl);
-          samlLogin();
-          cy.getCookie('security_authentication').should('exist');
-        });
+        cy.visit(gotoUrl);
+        samlLogin();
+        cy.getCookie('security_authentication').should('exist');
       });
     });
   });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -54,9 +54,10 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
-      failOnStatusCode: false,
-    });
+    cy.origin('http://localhost:5601', () => {
+      cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
+        failOnStatusCode: false,
+      });
 
     samlLogin();
 
@@ -68,9 +69,10 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
-      failOnStatusCode: false,
-    });
+    cy.origin('http://localhost:5601', () => {
+      cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+        failOnStatusCode: false,
+      });
 
     samlLogin();
 

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -59,10 +59,11 @@ describe('Log in via SAML', () => {
         failOnStatusCode: false,
       });
 
-    samlLogin();
+      samlLogin();
 
-    cy.get('#osdOverviewPageHeader__title').should('be.visible');
-    cy.getCookie('security_authentication').should('exist');
+      cy.get('#osdOverviewPageHeader__title').should('be.visible');
+      cy.getCookie('security_authentication').should('exist');
+    });
   });
 
   it('Login to app/dev_tools#/console when SAML is enabled', () => {
@@ -74,10 +75,11 @@ describe('Log in via SAML', () => {
         failOnStatusCode: false,
       });
 
-    samlLogin();
+      samlLogin();
 
-    cy.get('a.euiBreadcrumb--last').contains('Dev Tools');
-    cy.getCookie('security_authentication').should('exist');
+      cy.get('a.euiBreadcrumb--last').contains('Dev Tools');
+      cy.getCookie('security_authentication').should('exist');
+    });
   });
 
   it('Login to Dashboard with Hash', () => {

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -55,16 +55,12 @@ describe('Log in via SAML', () => {
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
-    try {
-      console.log(cy.url());
-    } catch (error) {
-      console.log(error);
-    }
 
-    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-      failOnStatusCode: false,
+    cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+        failOnStatusCode: false,
+      });
     });
-    console.log(cy.url());
 
     samlLogin();
 
@@ -76,8 +72,10 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
-      failOnStatusCode: false,
+    cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+      cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+        failOnStatusCode: false,
+      });
     });
 
     samlLogin();
@@ -92,8 +90,10 @@ describe('Log in via SAML', () => {
 
     const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
 
-    cy.visit(urlWithHash, {
-      failOnStatusCode: false,
+    cy.origin('http://localhost:7000', () => {
+      cy.visit(urlWithHash, {
+        failOnStatusCode: false,
+      });
     });
 
     samlLogin();
@@ -105,8 +105,11 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-      failOnStatusCode: false,
+
+    cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+        failOnStatusCode: false,
+      });
     });
 
     samlLogin();
@@ -141,7 +144,10 @@ describe('Log in via SAML', () => {
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
         const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
-        cy.visit(gotoUrl);
+        cy.origin('http://localhost:7000', () => {
+          cy.visit(gotoUrl);
+        });
+        
         samlLogin();
         cy.getCookie('security_authentication').should('exist');
       });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -53,15 +53,15 @@ describe('Log in via SAML', () => {
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
-  
+
     cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });
-  
-    cy.origin('http://localhost:7000', () => {
+
+    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
       samlLogin();
     });
-  
+
     cy.get('#osdOverviewPageHeader__title').should('be.visible');
     cy.getCookie('security_authentication').should('exist');
   });
@@ -74,7 +74,9 @@ describe('Log in via SAML', () => {
       failOnStatusCode: false,
     });
 
-    samlLogin();
+    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
+      samlLogin();
+    });
 
     cy.get('a.euiBreadcrumb--last').contains('Dev Tools');
     cy.getCookie('security_authentication').should('exist');
@@ -90,7 +92,9 @@ describe('Log in via SAML', () => {
       failOnStatusCode: false,
     });
 
-    samlLogin();
+    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
+      samlLogin();
+    });
 
     cy.get('h1.euiTitle--large').contains('Get started');
     cy.getCookie('security_authentication').should('exist');
@@ -119,7 +123,9 @@ describe('Log in via SAML', () => {
 
     cy.get('button[data-test-subj^="log-out-"]').click();
 
-    samlLogin();
+    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
+      samlLogin();
+    });
 
     cy.get('#user-icon-btn').should('be.visible');
     cy.get('#user-icon-btn').click();
@@ -137,7 +143,9 @@ describe('Log in via SAML', () => {
       cy.clearCookies().then(() => {
         const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
         cy.visit(gotoUrl);
-        samlLogin();
+        cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
+          samlLogin();
+        });
         cy.getCookie('security_authentication').should('exist');
       });
     });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -50,11 +50,11 @@ describe('Log in via SAML', () => {
     }
   };
 
-  it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
+  it('Login to app/wz-home#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/opensearch_dashboards_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/wz-home`, {
       failOnStatusCode: false,
     });
 
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/opensearch_dashboards_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/wz-home`, {
       failOnStatusCode: false,
     });
 

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -53,17 +53,22 @@ describe('Log in via SAML', () => {
   };
 
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
-    cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
-      localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
-      localStorage.setItem('home:newThemeModal:show', 'false');
-      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-        failOnStatusCode: false,
-      });
-      samlLogin();
+    cy.origin(
+      'http://localhost:7000',
+      { args: { basePath, samlLogin } },
+      ({ basePath, samlLogin }) => {
+        localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
+        localStorage.setItem('home:newThemeModal:show', 'false');
+        cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+          failOnStatusCode: false,
+        });
 
-      cy.get('#osdOverviewPageHeader__title').should('be.visible');
-      cy.getCookie('security_authentication').should('exist');
-    });
+        samlLogin();
+
+        cy.get('#osdOverviewPageHeader__title').should('be.visible');
+        cy.getCookie('security_authentication').should('exist');
+      }
+    );
   });
 
   it('Login to app/dev_tools#/console when SAML is enabled', () => {

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -29,7 +29,7 @@ before(() => {
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
   // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.origin('http://localhost:7000', () => {
+  cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
     cy.visit(`http://localhost:5601${basePath}`);
   });
 

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -29,7 +29,7 @@ before(() => {
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
   // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.visit(`http://localhost:7000${basePath}`);
+  cy.visit(`http://localhost:5601${basePath}`);
 
   cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
   cy.clearCookies();
@@ -54,7 +54,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/wz-home`, {
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
       failOnStatusCode: false,
     });
 
@@ -68,7 +68,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/dev_tools#/console`, {
+    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
       failOnStatusCode: false,
     });
 
@@ -82,7 +82,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    const urlWithHash = `http://localhost:7000${basePath}/app/security-dashboards-plugin#/getstarted`;
+    const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
 
     cy.visit(urlWithHash, {
       failOnStatusCode: false,
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/wz-home`, {
+    cy.visit(`http://localhost:5601${basePath}/app/wz-home`, {
       failOnStatusCode: false,
     });
 
@@ -133,7 +133,7 @@ describe('Log in via SAML', () => {
       // We need to explicitly clear cookies,
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
-        const gotoUrl = `http://localhost:7000${basePath}/goto/${response.urlId}?security_tenant=global`;
+        const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
         cy.visit(gotoUrl);
         samlLogin();
         cy.getCookie('security_authentication').should('exist');

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -53,14 +53,18 @@ describe('Log in via SAML', () => {
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
-
+    try {
+      console.log(cy.url());
+    } catch (error) {
+      console.log(error);
+    }
+    
     cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });
+    console.log(cy.url());
 
-    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
-      samlLogin();
-    });
+    samlLogin();
 
     cy.get('#osdOverviewPageHeader__title').should('be.visible');
     cy.getCookie('security_authentication').should('exist');
@@ -74,9 +78,7 @@ describe('Log in via SAML', () => {
       failOnStatusCode: false,
     });
 
-    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
-      samlLogin();
-    });
+    samlLogin();
 
     cy.get('a.euiBreadcrumb--last').contains('Dev Tools');
     cy.getCookie('security_authentication').should('exist');
@@ -92,9 +94,7 @@ describe('Log in via SAML', () => {
       failOnStatusCode: false,
     });
 
-    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
-      samlLogin();
-    });
+    samlLogin();
 
     cy.get('h1.euiTitle--large').contains('Get started');
     cy.getCookie('security_authentication').should('exist');
@@ -111,7 +111,6 @@ describe('Log in via SAML', () => {
     cy.get('#user-icon-btn').should('be.visible');
     cy.get('#user-icon-btn').click();
     cy.get('button[data-test-subj^="switch-tenants"]').click();
-
     cy.get('#private').should('be.enabled');
     cy.get('#private').click({ force: true });
 
@@ -123,9 +122,7 @@ describe('Log in via SAML', () => {
 
     cy.get('button[data-test-subj^="log-out-"]').click();
 
-    cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
-      samlLogin();
-    });
+    samlLogin();
 
     cy.get('#user-icon-btn').should('be.visible');
     cy.get('#user-icon-btn').click();
@@ -143,9 +140,7 @@ describe('Log in via SAML', () => {
       cy.clearCookies().then(() => {
         const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
         cy.visit(gotoUrl);
-        cy.origin('http://localhost:7000', { args: { samlLogin } }, ({ samlLogin }) => {
-          samlLogin();
-        });
+        samlLogin();
         cy.getCookie('security_authentication').should('exist');
       });
     });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -50,11 +50,11 @@ describe('Log in via SAML', () => {
     }
   };
 
-  it('Login to app/wz-home_overview#/ when SAML is enabled', () => {
+  it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });
 
@@ -97,7 +97,7 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:7000${basePath}/app/wz-home_overview`, {
+    cy.visit(`http://localhost:7000${basePath}/app/opensearch_dashboards_overview`, {
       failOnStatusCode: false,
     });
 


### PR DESCRIPTION
### Description

The `Ddest` flag in the `mvn` repository has been deprecated, This commit shows how the GitHub actions are changed:
https://github.com/opensearch-project/security-dashboards-plugin/commit/90b2e773b30861bde0ef5e16ea8fe0713ddf5512

Additionally, test `.github/workflows/cypress-test-tenancy-disabled.yml` has a mismatched test file. The commit changes the patch to fix it.

### Issues Resolved

- https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/183

### Testing

- The GitHub actions `Download security plugin and create setup scripts` must pass.
- The GitHub actions `Configure and Run OpenSearch Dashboards with Cypress Test Cases` must pass.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff