### PR TITLE
Change master branch references to main

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -12,7 +12,7 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: main
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -18,7 +18,7 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: main
         description: Source code reference (branch, tag or commit SHA)
 
 jobs:


### PR DESCRIPTION
### Description
This pull request changes the `master` branch references to `main`.

## Issue

Closes #178 