### PR TITLE
Update GitHub actions to use ubuntu 24.04

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -44,7 +44,7 @@ jobs:
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
This pull request changes the GitHub actions use of `ubuntu-latest` to `ubuntu-24.04` to prevent unexpected version changes in the image used.


### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard/issues/535

### Testing
- Verify the package building action works properly

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff
