### PR TITLE
Repository bumper script development

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+# Ignore repository bumper log files
+repository_bumper_*.log

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,59 @@
+# Versioning tools
+
+## repository_bumper.sh
+
+This script automates the process of updating the version and stage in the Wazuh Security Dashboards plugin repository, using only shell commands.
+
+### Usage
+
+```bash
+./repository_bumper.sh --version VERSION --stage STAGE [--help]
+```
+
+#### Parameters
+
+- `--version VERSION`
+  Specifies the new version (e.g., `4.6.0`).
+
+- `--stage STAGE`
+  Specifies the stage (e.g., `alpha0`, `beta1`, `rc2`, etc.).
+
+- `--help`
+  Shows help and exits.
+
+#### Examples
+
+```bash
+./repository_bumper.sh --version 4.6.0 --stage alpha0
+./repository_bumper.sh --version 4.6.0 --stage beta1
+```
+
+### What does the script do?
+
+1. **Validates input parameters** and shows error messages if they are incorrect.
+2. **Reads the current version and stage** from `VERSION.json` and the revision from `package.json`.
+3. **Compares the new version with the current one**:
+   - If the version changes (major, minor, or patch), it resets the revision to `00`.
+   - If the version is the same, it increments the revision.
+4. **Updates the files**:
+   - `VERSION.json`: Changes the `version` and `stage` fields.
+   - `package.json`: Changes the `version` and `revision` fields inside the `wazuh` object.
+   - `.github/workflows/manual-build.yml`: Updates the default value of the `reference` input if applicable.
+5. **Logs all actions** to a log file in the `tools` directory.
+
+### Notes
+
+- The script must be run from anywhere inside the git repository.
+- You need write permissions for the files to be modified.
+- The script uses `sed` to modify files, so the file format must be consistent.
+
+### Affected files
+
+- `VERSION.json`
+- `package.json`
+- `.github/workflows/manual-build.yml`
+
+### Log
+
+Each execution generates a log file in the `tools` directory with details of the operation.
+

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -244,6 +244,7 @@ update_package_json() {
   local PACKAGE_JSON="${REPO_PATH}/package.json" # Define path, assuming it's the main one
   if [ -f "$PACKAGE_JSON" ]; then
     log "Processing $PACKAGE_JSON"
+    local modified=false
     # Update version and revision in package.json
     # "wazuh": {
     #   "version": "4.13.0",
@@ -251,17 +252,27 @@ update_package_json() {
     # },
     # Update version and revision in package.json using the structure above
     # Use sed with address range to target lines within the "wazuh": { ... } block
-    log "Attempting to update version to $VERSION within 'wazuh' object in $PACKAGE_JSON"
-    # Note: This sed command assumes a specific formatting and might be fragile.
-    # It looks for the block starting with a line containing "wazuh": { and ending with the next line containing only }
-    # Within that block, it replaces the value on the line starting with "version":
-    sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"version\"\s*:\s*\)\"[^\"]*\"/\1\"$VERSION\"/" "$PACKAGE_JSON"
+    # Update version in package.json
+    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+      log "Attempting to update version to $VERSION within 'wazuh' object in $PACKAGE_JSON"
+      # Note: This sed command assumes a specific formatting and might be fragile.
+      # It looks for the block starting with a line containing "wazuh": { and ending with the next line containing only }
+      # Within that block, it replaces the value on the line starting with "version":
+      sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"version\"\s*:\s*\)\"[^\"]*\"/\1\"$VERSION\"/" "$PACKAGE_JSON"
+      modified=true
+    fi
 
-    log "Attempting to update revision to $REVISION within 'wazuh' object in $PACKAGE_JSON"
-    # Similar sed command for the revision line within the same block
-    sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"revision\"\s*:\s*\)\"[^\"]*\"/\1\"$REVISION\"/" "$PACKAGE_JSON"
+    # Update revision in package.json
+    if [[ "$CURRENT_REVISION" != "$REVISION" ]]; then
+      log "Attempting to update revision to $REVISION within 'wazuh' object in $PACKAGE_JSON"
+      # Similar sed command for the revision line within the same block
+      sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"revision\"\s*:\s*\)\"[^\"]*\"/\1\"$REVISION\"/" "$PACKAGE_JSON"
+      modified=true
+    fi
 
-    log "Successfully updated $PACKAGE_JSON with new version: $VERSION and stage: $STAGE"
+    if [[ $modified == true ]]; then
+      log "Successfully updated $PACKAGE_JSON with new version: $VERSION and revision: $REVISION"
+    fi
   else
     log "WARNING: $PACKAGE_JSON not found. Skipping update."
   fi

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -282,6 +282,7 @@ update_manual_build_workflow() {
   local WORKFLOW_FILE="${REPO_PATH}/.github/workflows/manual-build.yml"
   if [ -f "$WORKFLOW_FILE" ]; then
     log "Processing $WORKFLOW_FILE"
+    local modified=false
     # Update version in manual build workflow
     # on:
     #   workflow_call:
@@ -292,8 +293,18 @@ update_manual_build_workflow() {
     #         description: Source code reference (branch, tag or commit SHA)
     #         default: 4.13.0
     # Update the default value for the reference input
-    sed -i "s/^\(\s*default:\s*\)$CURRENT_VERSION/\1$VERSION/" "$WORKFLOW_FILE"
-    log "Successfully updated default reference in $WORKFLOW_FILE to: $VERSION"
+    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+      log "Attempting to update default reference to $VERSION in $WORKFLOW_FILE"
+      # Note: This sed command assumes a specific formatting and might be fragile.
+      # It looks for the line starting with "default:" and replaces the version value
+      # Ensure to escape special characters if necessary
+      sed -i "s/^\(\s*default:\s*\)$CURRENT_VERSION/\1$VERSION/" "$WORKFLOW_FILE"
+      modified=true
+    fi
+
+    if [[ $modified == true ]]; then
+      log "Successfully updated $WORKFLOW_FILE with new default reference: $VERSION"
+    fi
   else
     log "WARNING: $WORKFLOW_FILE not found. Skipping update."
   fi

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -201,9 +201,23 @@ update_root_version_json() {
   if [ -f "$VERSION_FILE" ]; then
     log "Processing $VERSION_FILE"
     # Update version and revision in VERSION.json
-    sed -i "s/^\s*\"version\"\s*:\s*\"[^\"]*\"/  \"version\": \"$VERSION\"/" "$VERSION_FILE"
-    sed -i "s/^\s*\"stage\"\s*:\s*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
-    log "Successfully updated $VERSION_FILE with new version: $VERSION and stage: $STAGE"
+    local modified=false
+
+    # Update version in VERSION.json
+    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+      sed -i "s/^\s*\"version\"\s*:\s*\"[^\"]*\"/  \"version\": \"$VERSION\"/" "$VERSION_FILE"
+      modified=true
+    fi
+
+    # Update stage in VERSION.json
+    if [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
+      sed -i "s/^\s*\"stage\"\s*:\s*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
+      modified=true
+    fi
+
+    if [[ $modified == true ]]; then
+      log "Successfully updated $VERSION_FILE with new version: $VERSION and stage: $STAGE"
+    fi
   else
     log "WARNING: $VERSION_FILE not found. Skipping update."
   fi

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -218,6 +218,29 @@ update_package_json() {
   fi
 }
 
+update_manual_build_workflow() {
+  local WORKFLOW_FILE="${REPO_PATH}/.github/workflows/manual-build.yml"
+  if [ -f "$WORKFLOW_FILE" ]; then
+    log "Processing $WORKFLOW_FILE"
+    # Update version in manual build workflow
+    # on:
+    #   workflow_call:
+    #     inputs:
+    #       reference:
+    #         required: true
+    #         type: string
+    #         description: Source code reference (branch, tag or commit SHA)
+    #         default: 4.13.0
+    # Update the default value for the reference input
+    sed -i "s/^\(\s*default:\s*\)$CURRENT_VERSION/\1$VERSION/" "$WORKFLOW_FILE"
+    log "Successfully updated default reference in $WORKFLOW_FILE to: $VERSION"
+  else
+    log "WARNING: $WORKFLOW_FILE not found. Skipping update."
+  fi
+  log "Updating manual build workflow..."
+
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -249,6 +272,7 @@ main() {
 
   update_root_version_json
   update_package_json
+  update_manual_build_workflow
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -128,6 +128,23 @@ pre_update_checks() {
   fi
   log "Current stage detected in VERSION.json: $CURRENT_STAGE"
 
+  # Attempt to extract current revision from package.json using sed
+  local PACKAGE_JSON="${REPO_PATH}/package.json"
+  log "Attempting to extract current revision from $PACKAGE_JSON using sed..."
+  CURRENT_REVISION=$(sed -n '/"wazuh": {/,/}/ s/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
+
+  if [ -z "$CURRENT_REVISION" ]; then
+    log "ERROR: Failed to extract 'revision' from $PACKAGE_JSON using sed. Check file format or key presence."
+    exit 1
+  fi
+  log "Successfully extracted revision using sed: $CURRENT_REVISION"
+
+  if [ "$CURRENT_REVISION" == "null" ]; then
+    log "ERROR: Could not read current revision from $PACKAGE_JSON (value was 'null')"
+    exit 1
+  fi
+  log "Current revision detected in package.json: $CURRENT_REVISION"
+
   log "Default revision set to: $REVISION" # Log default revision here
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -110,6 +110,24 @@ pre_update_checks() {
     exit 1
   fi
   log "Current version detected in VERSION.json: $CURRENT_VERSION"
+
+  # Attempt to extract stage from VERSION.json using sed
+  log "Attempting to extract current stage from $VERSION_FILE using sed..."
+  CURRENT_STAGE=$(sed -n 's/^\s*"stage"\s*:\s*"\([^"]*\)".*$/\1/p' "$VERSION_FILE" | head -n 1) # head -n 1 ensures only the first match is taken
+
+  # Check if sed successfully extracted a stage
+  if [ -z "$CURRENT_STAGE" ]; then
+    log "ERROR: Failed to extract 'stage' from $VERSION_FILE using sed. Check file format or key presence."
+    exit 1 # Exit if sed fails
+  fi
+  log "Successfully extracted stage using sed: $CURRENT_STAGE"
+
+  if [ "$CURRENT_STAGE" == "null" ]; then # Check specifically for "null" string if sed might output that
+    log "ERROR: Could not read current stage from $VERSION_FILE (value was 'null')"
+    exit 1
+  fi
+  log "Current stage detected in VERSION.json: $CURRENT_STAGE"
+
   log "Default revision set to: $REVISION" # Log default revision here
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+#
+# Wazuh Security Dashboards Plugin repository bumper (Pure Shell Version)
+# This script automates version and stage bumping across the repository using only shell commands.
+
+set -e
+
+# --- Global Variables ---
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
+DATE_TIME=$(date "+%Y-%m-%d_%H-%M-%S-%3N")
+LOG_FILE="${SCRIPT_PATH}/repository_bumper_${DATE_TIME}.log"
+VERSION_FILE="${REPO_PATH}/VERSION.json"
+VERSION=""
+REVISION="00"
+CURRENT_VERSION=""
+
+# --- Helper Functions ---
+
+# Function to log messages
+log() {
+  local message="$1"
+  local timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+  echo "[${timestamp}] ${message}" | tee -a "$LOG_FILE"
+}
+
+# Function to show usage
+usage() {
+  echo "Usage: $0 --version VERSION --stage STAGE [--help]"
+  echo ""
+  echo "Parameters:"
+  echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
+  echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
+  echo "  --help              Display this help message"
+  echo ""
+  echo "Example:"
+  echo "  $0 --version 4.6.0 --stage alpha0"
+  echo "  $0 --version 4.6.0 --stage beta1"
+}
+
+# --- Core Logic Functions ---
+
+parse_arguments() {
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "ERROR: Unknown option: $1" # Log error instead of just echo
+      usage
+      exit 1
+      ;;
+    esac
+  done
+}
+
+# Function to validate input parameters
+validate_input() {
+  if [ -z "$VERSION" ]; then
+    log "ERROR: Version parameter is required"
+    usage
+    exit 1
+  fi
+  if [ -z "$STAGE" ]; then
+    log "ERROR: Stage parameter is required"
+    usage
+    exit 1
+  fi
+  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log "ERROR: Version must be in the format x.y.z (e.g., 4.6.0)"
+    exit 1
+  fi
+  if ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
+    log "ERROR: Stage must be alphanumeric (e.g., alpha0, beta1, rc2)"
+    exit 1
+  fi
+}
+
+# Function to perform pre-update checks and gather initial data
+pre_update_checks() {
+  if [ ! -f "$VERSION_FILE" ]; then
+    log "ERROR: Root VERSION.json not found at $VERSION_FILE"
+    exit 1
+  fi
+
+  # Attempt to extract version from VERSION.json using sed
+  log "Attempting to extract current version from $VERSION_FILE using sed..."
+  CURRENT_VERSION=$(sed -n 's/^\s*"version"\s*:\s*"\([^"]*\)".*$/\1/p' "$VERSION_FILE" | head -n 1) # head -n 1 ensures only the first match is taken
+
+  # Check if sed successfully extracted a version
+  if [ -z "$CURRENT_VERSION" ]; then
+    log "ERROR: Failed to extract 'version' from $VERSION_FILE using sed. Check file format or key presence."
+    exit 1 # Exit if sed fails
+  fi
+  log "Successfully extracted version using sed: $CURRENT_VERSION"
+
+  if [ "$CURRENT_VERSION" == "null" ]; then # Check specifically for "null" string if sed might output that
+    log "ERROR: Could not read current version from $VERSION_FILE (value was 'null')"
+    exit 1
+  fi
+  log "Current version detected in VERSION.json: $CURRENT_VERSION"
+  log "Default revision set to: $REVISION" # Log default revision here
+}
+
+# Function to compare versions and determine revision
+compare_versions_and_set_revision() {
+  log "Comparing new version ($VERSION) with current version ($CURRENT_VERSION)..."
+
+  # Split versions into parts using '.' as delimiter
+  IFS='.' read -r -a NEW_VERSION_PARTS <<<"$VERSION"
+  IFS='.' read -r -a CURRENT_VERSION_PARTS <<<"$CURRENT_VERSION"
+
+  # Ensure both versions have 3 parts (Major.Minor.Patch)
+  if [ ${#NEW_VERSION_PARTS[@]} -ne 3 ] || [ ${#CURRENT_VERSION_PARTS[@]} -ne 3 ]; then
+    log "ERROR: Invalid version format detected during comparison. Both versions must be x.y.z."
+    exit 1
+  fi
+
+  # Compare Major version
+  if ((${NEW_VERSION_PARTS[0]} < ${CURRENT_VERSION_PARTS[0]})); then
+    log "ERROR: New major version (${NEW_VERSION_PARTS[0]}) cannot be lower than current major version (${CURRENT_VERSION_PARTS[0]})."
+    exit 1
+  elif ((${NEW_VERSION_PARTS[0]} > ${CURRENT_VERSION_PARTS[0]})); then
+    log "Version check passed: New version ($VERSION) is greater than current version ($CURRENT_VERSION) (Major increased)."
+    REVISION="00" # Reset revision on major increase
+  else
+    # Major versions are equal, compare Minor version
+    if ((${NEW_VERSION_PARTS[1]} < ${CURRENT_VERSION_PARTS[1]})); then
+      log "ERROR: New minor version (${NEW_VERSION_PARTS[1]}) cannot be lower than current minor version (${CURRENT_VERSION_PARTS[1]}) when major versions are the same."
+      exit 1
+    elif ((${NEW_VERSION_PARTS[1]} > ${CURRENT_VERSION_PARTS[1]})); then
+      log "Version check passed: New version ($VERSION) is greater than current version ($CURRENT_VERSION) (Minor increased)."
+      REVISION="00" # Reset revision on minor increase
+    else
+      # Major and Minor versions are equal, compare Patch version
+      if ((${NEW_VERSION_PARTS[2]} < ${CURRENT_VERSION_PARTS[2]})); then
+        log "ERROR: New patch version (${NEW_VERSION_PARTS[2]}) cannot be lower than current patch version (${CURRENT_VERSION_PARTS[2]}) when major and minor versions are the same."
+        exit 1
+      elif ((${NEW_VERSION_PARTS[2]} > ${CURRENT_VERSION_PARTS[2]})); then
+        log "Version check passed: New version ($VERSION) is greater than current version ($CURRENT_VERSION) (Patch increased)."
+        REVISION="00" # Reset revision on patch increase
+      else
+        # Versions are identical (Major, Minor, Patch are equal)
+        log "New version ($VERSION) is identical to current version ($CURRENT_VERSION). Incrementing revision."
+        local main_package_json="${REPO_PATH}/package.json" # Need path again
+        log "Attempting to extract current revision from $main_package_json using sed (Note: This is fragile)"
+        local current_revision_val=$(sed -n 's/^\s*"revision"\s*:\s*"\([^"]*\)".*$/\1/p' "$main_package_json" | head -n 1)
+        # Check if sed successfully extracted a revision
+        if [ -z "$current_revision_val" ]; then
+          log "ERROR: Failed to extract 'revision' from $main_package_json using sed. Check file format or key presence."
+          exit 1 # Exit if sed fails
+        fi
+        log "Successfully extracted revision using sed: $current_revision_val"
+        if [ -z "$current_revision_val" ] || [ "$current_revision_val" == "null" ]; then
+          log "ERROR: Could not read current revision from $main_package_json"
+          exit 1
+        fi
+        # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
+        local current_revision_int=$((10#$current_revision_val))
+        local new_revision_int=$((current_revision_int + 1))
+        # Format back to two digits with leading zero
+        REVISION=$(printf "%02d" "$new_revision_int")
+        log "Current revision: $current_revision_val. New revision set to: $REVISION"
+      fi
+    fi
+  fi
+  log "Final revision determined: $REVISION"
+}
+
+# Function to update VERSION.json
+update_root_version_json() {
+  if [ -f "$VERSION_FILE" ]; then
+    log "Processing $VERSION_FILE"
+    # Update version and revision in VERSION.json
+    sed -i "s/^\s*\"version\"\s*:\s*\"[^\"]*\"/  \"version\": \"$VERSION\"/" "$VERSION_FILE"
+    sed -i "s/^\s*\"stage\"\s*:\s*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
+    log "Successfully updated $VERSION_FILE with new version: $VERSION and stage: $STAGE"
+  else
+    log "WARNING: $VERSION_FILE not found. Skipping update."
+  fi
+}
+
+update_package_json() {
+  local PACKAGE_JSON="${REPO_PATH}/package.json" # Define path, assuming it's the main one
+  if [ -f "$PACKAGE_JSON" ]; then
+    log "Processing $PACKAGE_JSON"
+    # Update version and revision in package.json
+    # "wazuh": {
+    #   "version": "4.13.0",
+    #   "revision": "00"
+    # },
+    # Update version and revision in package.json using the structure above
+    # Use sed with address range to target lines within the "wazuh": { ... } block
+    log "Attempting to update version to $VERSION within 'wazuh' object in $PACKAGE_JSON"
+    # Note: This sed command assumes a specific formatting and might be fragile.
+    # It looks for the block starting with a line containing "wazuh": { and ending with the next line containing only }
+    # Within that block, it replaces the value on the line starting with "version":
+    sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"version\"\s*:\s*\)\"[^\"]*\"/\1\"$VERSION\"/" "$PACKAGE_JSON"
+
+    log "Attempting to update revision to $REVISION within 'wazuh' object in $PACKAGE_JSON"
+    # Similar sed command for the revision line within the same block
+    sed -i "/\"wazuh\": {/,/}/ s/^\(\s*\"revision\"\s*:\s*\)\"[^\"]*\"/\1\"$REVISION\"/" "$PACKAGE_JSON"
+
+    log "Successfully updated $PACKAGE_JSON with new version: $VERSION and stage: $STAGE"
+  else
+    log "WARNING: $PACKAGE_JSON not found. Skipping update."
+  fi
+}
+
+# --- Main Execution ---
+main() {
+  # Initialize log file
+  touch "$LOG_FILE"
+  log "Starting repository bump process"
+
+  # Check if inside a git repository early
+  if [ -z "$REPO_PATH" ]; then
+    # Use log function for consistency, redirect initial error to stderr
+    log "ERROR: Failed to determine repository root. Ensure you are inside the git repository." >&2
+    exit 1
+  fi
+  log "Repository path: $REPO_PATH"
+
+  # Parse and validate arguments
+  parse_arguments "$@"
+  validate_input
+  log "Version: $VERSION"
+  log "Stage: $STAGE"
+
+  # Perform pre-update checks
+  pre_update_checks
+
+  # Compare versions and determine revision
+  compare_versions_and_set_revision
+
+  # Start file modifications
+  log "Starting file modifications..."
+
+  update_root_version_json
+  update_package_json
+
+  log "File modifications completed."
+  log "Repository bump completed successfully. Log file: $LOG_FILE"
+  exit 0
+}
+
+# Execute main function with all script arguments
+main "$@"


### PR DESCRIPTION
### Description

We need to develop new functionality to automatically bump the version and stage of the repository.

The objective of this issue is to eliminate the need for manually changing repository details related to the version, stage, and other related data.

<details><summary>Requirements and restrictions</summary>

#### Script

- [x] Each repository bumper should be developed using a Unix shell script (.sh).
- [x] The repository bumper script should log its actions to a log file named `repository_bumper_{date_time}.log`, where `date_time` is the timestamp when the script is executed. For example: `repository_bumper_2025-04-04_18-47-04-670.log`.
- [x] The log file will be located in the same path as the script.
- [x] The repository bumper should report each file that is modified.
- [x] The repository bumper should be located in a `tools` directory at the root of the repository.
- [x] The repository bumper must accept the following parameters:
  - [x] `version`: string (e.g., x.y.z, such as 4.12.0)
  - [x] `stage`: string (e.g., textnumber, such as alpha0)

- The repository bumper may accept additional parameters depending on the specific repository, such as:
  - `date`: string (e.g., yyyy-mm-dd, such as 2025-04-13)
- Any other parameters required for the bump procedure, which are not listed here, should be communicated to the @wazuh/devel-xdrsiem-qa-leaders team.

</details>

Introduces a shell script to automate version and stage updates across the repository. Includes validation, logging and JSON/YAML updates. Adds a .gitignore entry to exclude generated log files.

### Category
Enhancement

### Issues Resolved

[Repository bumper script development · Issue #232 · wazuh/wazuh-security-dashboards-plugin](https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/232)

### Evidence

<details><summary>The repository bumper should be located in a `tools` directory at the root of the repository.</summary>
<p>

![image](https://github.com/user-attachments/assets/51ef30cd-f9b7-4913-bf58-886d2c7ebf8a)

</p>
</details> 

<details><summary>Version parameter is required</summary>
<p>

![image](https://github.com/user-attachments/assets/12afb2a1-0587-4e33-97af-02a0fb99909f)

</p>
</details> 

<details><summary>Stage parameter is required</summary>
<p>

![image](https://github.com/user-attachments/assets/431ace09-b80b-4ae9-8007-c3bcbd2307f1)

</p>
</details> 

<details><summary>Version must be in the format x.y.z (e.g., 4.6.0)</summary>
<p>

![image](https://github.com/user-attachments/assets/22c7cc7e-4b8f-46fb-a7a5-8ac0f2553135)

</p>
</details> 

<details><summary>Stage must be alphanumeric (e.g., alpha0, beta1, rc2)</summary>
<p>

![image](https://github.com/user-attachments/assets/3b845397-3f1e-4f8f-a067-b2f7f080ede0)

</p>
</details> 

<details><summary>New major version (2) cannot be lower than current major version (4).</summary>
<p>

![image](https://github.com/user-attachments/assets/67a8ed04-c4ac-4cf3-8f35-9348a772fc57)

</p>
</details> 

<details><summary>New minor version (12) cannot be lower than current minor version (13) when major versions are the same.</summary>
<p>

![image](https://github.com/user-attachments/assets/8422da0e-57b7-4258-80f5-1748c9786ae9)

</p>
</details> 

<details><summary>New patch version (0) cannot be lower than current patch version (1) when major and minor versions are the same.</summary>
<p>

![image](https://github.com/user-attachments/assets/a9436b9d-0549-4cd1-8938-5f2381018ba7)

</p>
</details> 

<details><summary>The repository bumper script should log its actions to a log file named `repository_bumper_{date_time}.log`, where `date_time` is the timestamp when the script is executed. For example: `repository_bumper_2025-04-04_18-47-04-670.log` and the log file will be located in the same path as the script.</summary>
<p>

![image](https://github.com/user-attachments/assets/cda4f053-2411-4dd6-aa56-ca2a3bd8d498)

</p>
</details> 

<details><summary>When keeping the same version, only the revision should be modified. The repository bumper should report each file that is modified.</summary>
<p>

```console
./repository_bumper.sh --version 4.13.0 --stage alpha1
```

![image](https://github.com/user-attachments/assets/4a653cbe-68bd-4c08-9416-d36e144d7696)

```diff
diff --git a/package.json b/package.json
index 47a0b13..7b37381 100644
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "wazuh": {
     "version": "4.13.0",
-    "revision": "00"
+    "revision": "01"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",
``` 
</p>
</details> 

<details><summary>When you keep the version but change the Stage, only the revision should be modified in corresponding files and the Stage in VERSION.json.</summary>
<p>

```console
./repository_bumper.sh --version 4.13.0 --stage alpha2
``` 

![image](https://github.com/user-attachments/assets/452ead21-018a-4152-887c-b7a7ffb6b19d)

```diff
diff --git a/VERSION.json b/VERSION.json
index 3747a84..dd717eb 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "4.13.0",
-  "stage": "alpha1"
+  "stage": "alpha2"
 }
diff --git a/package.json b/package.json
index 47a0b13..7b37381 100644
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "wazuh": {
     "version": "4.13.0",
-    "revision": "00"
+    "revision": "01"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",
``` 

</p>
</details> 

<details><summary>When changing the version, specifically the patch version, only the corresponding files should be updated and the revision should be set to zero. And a new entry should be added to the CHANGELOG, with the new version and the revision set to zero.</summary>
<p>

```console
./repository_bumper.sh --version 4.13.1 --stage alpha1
``` 

![image](https://github.com/user-attachments/assets/bedac06b-20ad-464c-b9f1-25e8ccd0645e)

```diff
diff --git a/.github/workflows/manual-build.yml b/.github/workflows/manual-build.yml
index 97a02db..f9d6ba1 100644
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
         description: Source code reference (branch, tag or commit SHA)
-        default: 4.13.0
+        default: 4.13.1
   workflow_dispatch:
     inputs:
       reference:
diff --git a/VERSION.json b/VERSION.json
index 3747a84..5c9c009 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.13.0",
+  "version": "4.13.1",
   "stage": "alpha1"
 }
diff --git a/package.json b/package.json
index 47a0b13..a40e51d 100644
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "templateVersion": "2.19.1"
   },
   "wazuh": {
-    "version": "4.13.0",
+    "version": "4.13.1",
     "revision": "00"
   },
   "license": "Apache-2.0",
``` 

</p>
</details> 

### Test

For this testing section, you should follow the steps outlined in the evidence.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

- [x] Add README.md