### PR TITLE
Bump Wazuh version to 4.10.2

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
         description: Source code reference (branch, tag or commit SHA)
-        default: 4.10.1
+        default: 4.10.2
   workflow_dispatch:
     inputs:
       reference:

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "templateVersion": "2.16.0"
   },
   "wazuh": {
-    "version": "4.10.1",
-    "revision": "01"
+    "version": "4.10.2",
+    "revision": "00"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",


### PR DESCRIPTION
### Description

This pull request bumps Wazuh version to support 4.10.2.

### Issues Resolved
- https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/248

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff
