### PR TITLE
Adds repository version bumper workflows and improves portability

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -1,0 +1,135 @@
+name: Repository bumper
+run-name: Bump ${{ github.ref_name }} (${{ inputs.id }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target version (e.g. 1.2.3)'
+        default: ''
+        required: false
+        type: string
+      stage:
+        description: 'Version stage (e.g. alpha0)'
+        default: ''
+        required: false
+        type: string
+      issue-link:
+        description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
+        required: true
+        type: string
+      id:
+        description: 'Optional identifier for the run'
+        required: false
+        type: string
+
+jobs:
+  bump:
+    name: Repository bumper
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      CI_COMMIT_AUTHOR: wazuhci
+      CI_COMMIT_EMAIL: 22834044+wazuhci@users.noreply.github.com
+      CI_GPG_PRIVATE_KEY: ${{ secrets.CI_WAZUHCI_GPG_PRIVATE }}
+      GH_TOKEN: ${{ secrets.CI_WAZUHCI_BUMPER_TOKEN }}
+      BUMP_SCRIPT_PATH: tools/repository_bumper.sh
+      BUMP_LOG_PATH: tools/
+
+    steps:
+      - name: Dump event payload
+        run: |
+          cat $GITHUB_EVENT_PATH | jq '.inputs'
+
+      - name: Set up GPG key
+        id: signing_setup
+        run: |
+          echo "${{ env.CI_GPG_PRIVATE_KEY }}" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+          echo "gpg_key_id=$KEY_ID" >> $GITHUB_OUTPUT
+
+      - name: Set up git
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+          git config --global commit.gpgsign true
+          git config --global user.signingkey "${{ steps.signing_setup.outputs.gpg_key_id }}"
+          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          echo RELOADAGENT | gpg-connect-agent
+          export DEBIAN_FRONTEND=noninteractive
+          export GPG_TTY=$(tty)
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Using workflow-specific GITHUB_TOKEN because currently CI_WAZUHCI_BUMPER_TOKEN
+          # doesn't have all the necessary permissions
+          token: ${{ env.GH_TOKEN }}
+
+      - name: Determine branch name
+        id: vars
+        env:
+          VERSION: ${{ inputs.version }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          script_params=""
+          version=${{ env.VERSION }}
+          stage=${{ env.STAGE }}
+
+          # Both version and stage provided
+          if [[ -n "$version" && -n "$stage" ]]; then
+            script_params="--version ${version} --stage ${stage}"
+          elif [[ -z "$version" && -n "$stage" ]]; then
+            script_params="--stage ${stage}"
+          fi
+
+          issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
+          BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "script_params=${script_params}" >> $GITHUB_OUTPUT
+
+      - name: Create and switch to bump branch
+        run: |
+          git checkout -b ${{ steps.vars.outputs.branch_name }}
+
+      - name: Make version bump changes
+        run: |
+          echo "Running bump script"
+          bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
+
+      - name: Commit and push changes
+        run: |
+          git add .
+          git commit -m "feat: bump ${{ github.ref_name }}"
+          git push origin ${{ steps.vars.outputs.branch_name }}
+
+      - name: Create pull request
+        id: create_pr
+        run: |
+          gh auth setup-git
+          PR_URL=$(gh pr create \
+            --title "Bump ${{ github.ref_name }} branch" \
+            --body "Issue: ${{ inputs.issue-link }}" \
+            --base ${{ github.ref_name }} \
+            --head ${{ steps.vars.outputs.branch_name }})
+
+          echo "Pull request created: ${PR_URL}"
+          echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
+
+      - name: Merge pull request
+        run: |
+          # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+
+      - name: Show logs
+        run: |
+          echo "Bump complete."
+          echo "Branch: ${{ steps.vars.outputs.branch_name }}"
+          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          echo "Bumper scripts logs:"
+          cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/.github/workflows/6_bumper_repository.yml
+++ b/.github/workflows/6_bumper_repository.yml
@@ -1,0 +1,135 @@
+name: Repository bumper
+run-name: Bump ${{ github.ref_name }} (${{ inputs.id }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target version (e.g. 1.2.3)'
+        default: ''
+        required: false
+        type: string
+      stage:
+        description: 'Version stage (e.g. alpha0)'
+        default: ''
+        required: false
+        type: string
+      issue-link:
+        description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
+        required: true
+        type: string
+      id:
+        description: 'Optional identifier for the run'
+        required: false
+        type: string
+
+jobs:
+  bump:
+    name: Repository bumper
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      CI_COMMIT_AUTHOR: wazuhci
+      CI_COMMIT_EMAIL: 22834044+wazuhci@users.noreply.github.com
+      CI_GPG_PRIVATE_KEY: ${{ secrets.CI_WAZUHCI_GPG_PRIVATE }}
+      GH_TOKEN: ${{ secrets.CI_WAZUHCI_BUMPER_TOKEN }}
+      BUMP_SCRIPT_PATH: tools/repository_bumper.sh
+      BUMP_LOG_PATH: tools/
+
+    steps:
+      - name: Dump event payload
+        run: |
+          cat $GITHUB_EVENT_PATH | jq '.inputs'
+
+      - name: Set up GPG key
+        id: signing_setup
+        run: |
+          echo "${{ env.CI_GPG_PRIVATE_KEY }}" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+          echo "gpg_key_id=$KEY_ID" >> $GITHUB_OUTPUT
+
+      - name: Set up git
+        run: |
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"
+          git config --global commit.gpgsign true
+          git config --global user.signingkey "${{ steps.signing_setup.outputs.gpg_key_id }}"
+          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          echo RELOADAGENT | gpg-connect-agent
+          export DEBIAN_FRONTEND=noninteractive
+          export GPG_TTY=$(tty)
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Using workflow-specific GITHUB_TOKEN because currently CI_WAZUHCI_BUMPER_TOKEN
+          # doesn't have all the necessary permissions
+          token: ${{ env.GH_TOKEN }}
+
+      - name: Determine branch name
+        id: vars
+        env:
+          VERSION: ${{ inputs.version }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          script_params=""
+          version=${{ env.VERSION }}
+          stage=${{ env.STAGE }}
+
+          # Both version and stage provided
+          if [[ -n "$version" && -n "$stage" ]]; then
+            script_params="--version ${version} --stage ${stage}"
+          elif [[ -z "$version" && -n "$stage" ]]; then
+            script_params="--stage ${stage}"
+          fi
+
+          issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
+          BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "script_params=${script_params}" >> $GITHUB_OUTPUT
+
+      - name: Create and switch to bump branch
+        run: |
+          git checkout -b ${{ steps.vars.outputs.branch_name }}
+
+      - name: Make version bump changes
+        run: |
+          echo "Running bump script"
+          bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
+
+      - name: Commit and push changes
+        run: |
+          git add .
+          git commit -m "feat: bump ${{ github.ref_name }}"
+          git push origin ${{ steps.vars.outputs.branch_name }}
+
+      - name: Create pull request
+        id: create_pr
+        run: |
+          gh auth setup-git
+          PR_URL=$(gh pr create \
+            --title "Bump ${{ github.ref_name }} branch" \
+            --body "Issue: ${{ inputs.issue-link }}" \
+            --base ${{ github.ref_name }} \
+            --head ${{ steps.vars.outputs.branch_name }})
+
+          echo "Pull request created: ${PR_URL}"
+          echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
+
+      - name: Merge pull request
+        run: |
+          # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+
+      - name: Show logs
+        run: |
+          echo "Bump complete."
+          echo "Branch: ${{ steps.vars.outputs.branch_name }}"
+          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          echo "Bumper scripts logs:"
+          cat ${BUMP_LOG_PATH}/repository_bumper*log


### PR DESCRIPTION
### Description

Propagation of the bumper repository script
Fix to make it work on macOS

### Issue

- #318 

<details><summary>bash ./repository_bumper.sh --version 5.1.0 --stage alpha1</summary>
<p>

<img width="578" alt="image" src="https://github.com/user-attachments/assets/bdf94e6e-787d-46fb-9d06-34e70f02d7f7" />

</p>
</details> 

<details><summary>bash ./repository_bumper.sh --version 5.1.0 --stage alpha2</summary>
<p>

<img width="603" alt="image" src="https://github.com/user-attachments/assets/65a36286-e256-4f91-be99-6f8466915894" />

</p>
</details> 
