### PR TITLE
Reduce default session cookie timeout

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -62,7 +62,7 @@ export const configSchema = schema.object({
     secure: schema.boolean({ defaultValue: false }),
     name: schema.string({ defaultValue: 'security_authentication' }),
     password: schema.string({ defaultValue: 'security_cookie_default_password', minLength: 32 }),
-    ttl: schema.number({ defaultValue: 60 * 60 * 1000 }),
+    ttl: schema.number({ defaultValue: 15 * 60 * 1000 }),
     domain: schema.nullable(schema.string()),
     isSameSite: schema.oneOf(
       [
@@ -75,7 +75,7 @@ export const configSchema = schema.object({
     ),
   }),
   session: schema.object({
-    ttl: schema.number({ defaultValue: 60 * 60 * 1000 }),
+    ttl: schema.number({ defaultValue: 15 * 60 * 1000 }),
     keepalive: schema.boolean({ defaultValue: true }),
   }),
   auth: schema.object({


### PR DESCRIPTION
### Description
Set default session and cookie TTL to 15 minutes (900000 ms) . Previously, the session expired after 1 hour.
If no opensearch_security config for session ttl and cookie ttl, it will use the 15-minute default value


### Category
[Enhancement/Change]


### What is the old behavior before changes and new behavior after changes?
Previously, the session and cookie expired after 1 hour.

### Issues Resolved
[#739](https://github.com/wazuh/wazuh-dashboard/issues/739)

## Evidence

<details>
<summary>After 15 minutes of inactivity, the session log out:</summary>
<img width="1764" alt="Screenshot 2025-06-26 at 4 21 36 PM" src="https://github.com/user-attachments/assets/16564a77-21fe-4cc5-8cff-881b0c505144" />

https://github.com/user-attachments/assets/3498cf96-68a2-4ad4-95f6-6dd3ae29e1fd

</details>

## Testing the changes

1. Use this repo and the 4.13.1 `wazuh-dashboard` repository
2. Start the environment:
   ```bash
   ./dev.sh up security
3. Once the dashboard is running, log in.
4. Remain inactive for 15 minutes.
5. Confirm that the session expires and you are redirected to the login screen.


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).