### PR TITLE
Add Wazuh version concatenation to GitHub workflows for combined package naming

### DIFF
--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -78,15 +78,15 @@ jobs:
           echo "Wazuh version: $wazuh_version";
           
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>
-          platform_version="${platform_version}-${wazuh_version}";
-          echo "Combined platform version: $platform_version";
+          combined_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $combined_version";
 
           # Up the environment and run the command
           docker run -t --rm \
-            -e OPENSEARCH_DASHBOARDS_VERSION=${platform_version} \
+            -e OPENSEARCH_DASHBOARDS_VERSION=${combined_version} \
             -v `pwd`/wazuh-security-plugin:/home/node/kbn/plugins/wazuh-security-plugin \
             ${{ inputs.docker_run_extra_args }} \
-            quay.io/wazuh/osd-dev:${platform_version} \
+            quay.io/wazuh/osd-dev:${combined_version} \
             bash -c '
               yarn config set registry https://registry.yarnpkg.com;
               cd /home/node/kbn/plugins/wazuh-security-plugin && yarn && ${{ inputs.command }};

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -73,6 +73,14 @@ jobs:
           platform_version=$(jq -r '.opensearchDashboards.version | select(. != null)' wazuh-security-plugin/package.json);
           echo "Plugin platform version: $platform_version";
 
+          # Get Wazuh version and concatenate with platform version
+          wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
+          echo "Wazuh version: $wazuh_version";
+          
+          # Concatenate versions in format: <Opensearch version>-<Wazuh version>
+          platform_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $platform_version";
+
           # Up the environment and run the command
           docker run -t --rm \
             -e OPENSEARCH_DASHBOARDS_VERSION=${platform_version} \

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -74,7 +74,7 @@ jobs:
           echo "Plugin platform version: $platform_version";
 
           # Get Wazuh version and concatenate with platform version
-          wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
+          wazuh_version=$(jq -r '.wazuh.version' wazuh-security-plugin/package.json);
           echo "Wazuh version: $wazuh_version";
           
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -67,6 +67,14 @@ jobs:
           platform_version=$(jq -r '.opensearchDashboards.version | select(. != null)' wazuh-security-plugin/package.json);
           echo "Plugin platform version: $platform_version";
 
+          # Get Wazuh version and concatenate with platform version
+          wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
+          echo "Wazuh version: $wazuh_version";
+          
+          # Concatenate versions in format: <Opensearch version>-<Wazuh version>
+          platform_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $platform_version";
+
           # Up the environment and run the command
           docker run -t --rm \
             -e OPENSEARCH_DASHBOARDS_VERSION=${platform_version} \

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -68,7 +68,7 @@ jobs:
           echo "Plugin platform version: $platform_version";
 
           # Get Wazuh version and concatenate with platform version
-          wazuh_version=$(jq -r '.version' ${{ matrix.plugins.path }}/package.json);
+          wazuh_version=$(jq -r '.wazuh.version' wazuh-security-plugin/package.json);
           echo "Wazuh version: $wazuh_version";
           
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -72,15 +72,15 @@ jobs:
           echo "Wazuh version: $wazuh_version";
           
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>
-          platform_version="${platform_version}-${wazuh_version}";
-          echo "Combined platform version: $platform_version";
+          combined_version="${platform_version}-${wazuh_version}";
+          echo "Combined platform version: $combined_version";
 
           # Up the environment and run the command
           docker run -t --rm \
-            -e OPENSEARCH_DASHBOARDS_VERSION=${platform_version} \
+            -e OPENSEARCH_DASHBOARDS_VERSION=${combined_version} \
             -v `pwd`/wazuh-security-plugin:/home/node/kbn/plugins/wazuh-security-plugin \
             ${{ inputs.docker_run_extra_args }} \
-            quay.io/wazuh/osd-dev:${platform_version} \
+            quay.io/wazuh/osd-dev:${combined_version} \
             bash -c '
               yarn config set registry https://registry.yarnpkg.com;
               cd /home/node/kbn/plugins/wazuh-security-plugin && yarn && ${{ inputs.command }};


### PR DESCRIPTION
### Description
This PR enhances GitHub workflows to include Wazuh version retrieval and concatenation with the OpenSearch platform version. This update improves version management in the development environment and builder workflows by creating a combined version format `<Opensearch version>-<Wazuh version>` (e.g., `3.0.0-5.0.0`).

**Changes made:**
- Corrected the field access from `.version` to `.wazuh.version` to properly extract the Wazuh version
- Added Wazuh version retrieval and concatenation with platform version in the workflow
- Implemented combined version format for Docker image naming: `<Opensearch version>-<Wazuh version>`
- Added proper logging to show the combined version being used in the workflow
- Ensured the workflow can successfully retrieve and combine versions from the package.json structure

### Issues Resolved
- [#7577](https://github.com/wazuh/wazuh-dashboard-plugins/issues/7577)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).