### PR TITLE
Adds version-specific dashboard build workflows (4.10.4)

### DIFF
--- a/.github/workflows/4_builderpackage_security_plugin.yml
+++ b/.github/workflows/4_builderpackage_security_plugin.yml
@@ -28,7 +28,7 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: 4.10.4
         description: Source code reference (branch, tag or commit SHA)
 
 jobs:

--- a/.github/workflows/4_builderpackage_security_plugin.yml
+++ b/.github/workflows/4_builderpackage_security_plugin.yml
@@ -1,0 +1,46 @@
+# 📝 Based on: `4_builderprecompiled_base-dev-environment.yml`
+#
+# 📦 Manual Build Workflow for Wazuh Security Dashboard Plugin
+#
+# ⚡ Overview:
+# This workflow builds and tests production-ready packages for Wazuh Security Dashboard Plugin,
+# either manually or triggered by other workflows.
+#
+# 🚀 Key Features:
+# - 🖇️ Manual or Automated Builds: Supports manual execution or invocation from other workflows,
+#   specifying any valid code reference (branch, tag, or commit SHA).
+# - 🏗️ Production-Ready Package Generation: Builds a production-ready package from the provided code reference.
+# - 🌐 Reusable Build Environment: Reuses a preconfigured build environment, ensuring consistency and easier maintenance.
+#
+
+name: (4.x) Build app package (on demand)
+
+on:
+  workflow_call:
+    inputs:
+      reference:
+        required: true
+        type: string
+        description: Source code reference (branch, tag or commit SHA)
+        default: 4.10.4
+  workflow_dispatch:
+    inputs:
+      reference:
+        required: true
+        type: string
+        default: master
+        description: Source code reference (branch, tag or commit SHA)
+
+jobs:
+  # Build an app package from the given source code reference.
+  build:
+    name: Build app package
+    uses: ./.github/workflows/4_builderprecompiled_base-dev-environment.yml
+    permissions: 
+      pull-requests: write
+    with:
+      reference: ${{ inputs.reference }}
+      command: 'yarn build'
+      artifact_name: 'wazuh-security-dashboards-plugin'
+      artifact_path: './wazuh-security-plugin/build'
+    secrets: inherit

--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -12,7 +12,7 @@
 #
 # 🔗 Designed for: Easy integration and reuse by other workflows.
 
-name: Base workflow - Environment
+name: (4.x) Base workflow - Environment
 
 on:
   workflow_call:
@@ -20,7 +20,7 @@ on:
       reference:
         required: true
         type: string
-        default: master
+        default: 4.10.4
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true

--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -1,0 +1,108 @@
+# 📚 Base Workflow - Environment Setup and Command Execution
+#
+# ⚡ Overview:
+# This workflow serves as a reusable base for other workflows, providing a
+# standardized environment to execute custom commands (e.g., `yarn build`, `yarn test`)
+# on source code fetched from a specified Git reference.
+#
+# 🚀 Key Features:
+# - 💻 Docker-Based Environment Setup: Prepares a Docker environment with OpenSearch Dashboards or Kibana.
+# - ⚙️ Custom Command Execution: Runs any specified command on the downloaded source code.
+# - 📦 Artifact and Coverage Upload: Uploads build artifacts and test coverage results to GitHub when configured.
+#
+# 🔗 Designed for: Easy integration and reuse by other workflows.
+
+name: Base workflow - Environment
+
+on:
+  workflow_call:
+    inputs:
+      reference:
+        required: true
+        type: string
+        default: master
+        description: Source code reference (branch, tag or commit SHA).
+      command:
+        required: true
+        type: string
+        default: 'yarn build'
+        description: Command to run in the environment
+      docker_run_extra_args:
+        type: string
+        default: ''
+        description: Additional paramaters for the docker run command.
+        required: false
+      artifact_name:
+        type: string
+        default: ''
+        description: Artifact name (will be automatically suffixed with .zip)
+        required: false
+      artifact_path:
+        type: string
+        default: ''
+        description: Folder to include in the archive.
+        required: false
+      notify_jest_coverage_summary:
+        type: boolean
+        default: false
+        required: false
+
+jobs:
+  # Deploy the plugin in a development environment and run a command
+  # using a pre-built Docker image, hosted in Quay.io.
+  deploy_and_run_command:
+    permissions: 
+      pull-requests: write
+    name: Deploy and run command
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Step 01 - Download the plugin's source code
+        uses: actions/checkout@v4
+        with:
+          repository: wazuh/wazuh-security-dashboards-plugin
+          ref: ${{ inputs.reference }}
+          path: wazuh-security-plugin
+
+      # Fix source code ownership so the internal user of the Docker
+      # container is also owner.
+      - name: Step 02 - Change code ownership
+        run: sudo chown 1000:1000 -R wazuh-security-plugin;
+
+      - name: Step 03 - Set up the environment and run the command
+        run: |
+          # Read the platform version from the package.json file
+          echo "Reading the platform version from the package.json...";
+          platform_version=$(jq -r '.opensearchDashboards.version | select(. != null)' wazuh-security-plugin/package.json);
+          echo "Plugin platform version: $platform_version";
+
+          # Up the environment and run the command
+          docker run -t --rm \
+            -e OPENSEARCH_DASHBOARDS_VERSION=${platform_version} \
+            -v `pwd`/wazuh-security-plugin:/home/node/kbn/plugins/wazuh-security-plugin \
+            ${{ inputs.docker_run_extra_args }} \
+            quay.io/wazuh/osd-dev:${platform_version} \
+            bash -c '
+              yarn config set registry https://registry.yarnpkg.com;
+              cd /home/node/kbn/plugins/wazuh-security-plugin && yarn && ${{ inputs.command }};
+            '
+      - name: Get the plugin version and and format reference name
+        run: |
+          echo "githubReference=$(echo ${{ inputs.reference }} | sed 's/\//-/g')" >> $GITHUB_ENV
+          echo "version=$(jq -r '.wazuh.version' $(pwd)/wazuh-security-plugin/package.json)" >> $GITHUB_ENV
+          echo "revision=$(jq -r '.wazuh.revision' $(pwd)/wazuh-security-plugin/package.json)" >> $GITHUB_ENV
+
+      - name: Step 04 - Upload artifact to GitHub
+        if: ${{ inputs.artifact_name && inputs.artifact_path }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}_${{ env.version }}-${{ env.revision }}_${{ env.githubReference }}.zip
+          path: ${{ inputs.artifact_path }}
+          overwrite: true
+
+      - name: Step 05 - Upload coverage results to GitHub
+        if: ${{ inputs.notify_jest_coverage_summary && github.event_name == 'pull_request' }}
+        uses: AthleticNet/comment-test-coverage@1.2.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./wazuh-security-plugin/target/test-coverage/coverage-summary.json
+          title: 'Code coverage (Jest)'


### PR DESCRIPTION
### Description

Add build dashboard and dashboard_core actions 4.x versions according to major_prefix_target nomenclature

### Evidence

https://github.com/yenienserrano/wazuh-dashboard/actions/runs/17138016173

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).