### PR TITLE
implement retry logic for yarn install in workflows

### DIFF
--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -82,8 +82,33 @@ jobs:
             ${{ inputs.docker_run_extra_args }} \
             quay.io/wazuh/osd-dev:${platform_version} \
             bash -c '
+              set -e;
               yarn config set registry https://registry.yarnpkg.com;
-              cd /home/node/kbn/plugins/wazuh-security-plugin && yarn && ${{ inputs.command }};
+
+              cd /home/node/kbn/plugins/wazuh-security-plugin;
+
+              max_attempts="${RETRY_MAX_ATTEMPTS:-3}";
+              delay_seconds="${RETRY_DELAY_SECONDS:-15}";
+              attempt=1;
+
+              while [ "${attempt}" -le "${max_attempts}" ]; do
+                echo "Performing yarn install (attempt ${attempt}/${max_attempts})...";
+                if yarn install --non-interactive; then
+                  break;
+                else
+                  exit_code=$?;
+                fi;
+                if [ "${attempt}" -ge "${max_attempts}" ]; then
+                  echo "yarn install failed after ${max_attempts} attempts (exit code ${exit_code})." >&2;
+                  exit "${exit_code}";
+                fi;
+
+                echo "yarn install failed (attempt ${attempt}/${max_attempts}, exit ${exit_code}). Retrying in ${delay_seconds}s..." >&2;
+                sleep "${delay_seconds}";
+                attempt=$((attempt + 1));
+              done;
+
+              ${{ inputs.command }};
             '
       - name: Get the plugin version and format reference name
         run: |

--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -74,8 +74,33 @@ jobs:
             ${{ inputs.docker_run_extra_args }} \
             quay.io/wazuh/osd-dev:${platform_version} \
             bash -c '
+              set -e;
               yarn config set registry https://registry.yarnpkg.com;
-              cd /home/node/kbn/plugins/wazuh-security-plugin && yarn && ${{ inputs.command }};
+
+              cd /home/node/kbn/plugins/wazuh-security-plugin;
+
+              max_attempts="${RETRY_MAX_ATTEMPTS:-3}";
+              delay_seconds="${RETRY_DELAY_SECONDS:-15}";
+              attempt=1;
+
+              while [ "${attempt}" -le "${max_attempts}" ]; do
+                echo "Performing yarn install (attempt ${attempt}/${max_attempts})...";
+                if yarn install --non-interactive; then
+                  break;
+                else
+                  exit_code=$?;
+                fi;
+                if [ "${attempt}" -ge "${max_attempts}" ]; then
+                  echo "yarn install failed after ${max_attempts} attempts (exit code ${exit_code})." >&2;
+                  exit "${exit_code}";
+                fi;
+
+                echo "yarn install failed (attempt ${attempt}/${max_attempts}, exit ${exit_code}). Retrying in ${delay_seconds}s..." >&2;
+                sleep "${delay_seconds}";
+                attempt=$((attempt + 1));
+              done;
+
+              ${{ inputs.command }};
             '
       - name: Get the plugin version and format reference name
         run: |


### PR DESCRIPTION
### Description

Add a retry mechanism for the «yarn install» command in the deployment scripts of both the base and dev environment workflows. This change aims to enhance the robustness of the installation process by allowing multiple attempts in case of transient failures, thus reducing the likelihood of internal server errors during package fetching.

### Category
Bug fix

### Issues Resolved

[\[BUG\] Internal server error fetching concat package · Issue #1038 · wazuh/wazuh-dashboard](https://github.com/wazuh/wazuh-dashboard/issues/1038)

### Testing

Action: https://github.com/wazuh/wazuh-security-dashboards-plugin/actions/runs/20273449927
- https://github.com/wazuh/wazuh-security-dashboards-plugin/actions/runs/20273449927/job/58215346727#step:4:107

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).