### PR TITLE
Revert "Bump 4.14.3 branch"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "wazuh": {
     "version": "4.14.3",
-    "revision": "02"
+    "revision": "01"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",


### PR DESCRIPTION
Reverts wazuh/wazuh-security-dashboards-plugin#451, unnecessary revision bump.