### PR TITLE
Update GitHub Actions workflows to use custom wz-linux runners. (main)

### DIFF
--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: wz-linux-amd64
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -52,7 +52,7 @@ jobs:
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: ubuntu-latest
+    runs-on: wz-linux-amd64
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
           # Get Wazuh version and concatenate with platform version
           wazuh_version=$(jq -r '.wazuh.version' wazuh-security-plugin/package.json);
           echo "Wazuh version: $wazuh_version";
-          
+
           # Concatenate versions in format: <Opensearch version>-<Wazuh version>
           combined_version="${platform_version}-${wazuh_version}";
           echo "Combined platform version: $combined_version";


### PR DESCRIPTION
### Description

Replace GitHub-hosted runners with Wazuh self-hosted runners (wz-linux-amd64) across all base build workflows.

##### Changes

- 4_builderprecompiled_base-dev-environment.yml: ubuntu-24.04 → wz-linux-amd64
- 5_builderprecompiled_base-dev-environment.yml: ubuntu-24.04 → wz-linux-amd64
- 6_builderprecompiled_base-dev-environment.yml: ubuntu-latest → wz-linux-amd64

### Issue 

- https://github.com/wazuh/wazuh-dashboard/issues/1129

### Evidence

- [(5.x) Build app package (on demand)](https://github.com/wazuh/wazuh-security-dashboards-plugin/actions/runs/22412173537)