### PR TITLE
Add `--set-as-main` flag support to repository bumper — `wazuh-dashboard-notifications`

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -22,6 +22,11 @@ on:
         description: 'Optional identifier for the run'
         required: false
         type: string
+      set_as_main:
+        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   bump:
@@ -76,8 +81,8 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          SET_AS_MAIN: ${{ inputs.set_as_main }}
         run: |
-          script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
 
@@ -91,7 +96,9 @@ jobs:
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
           BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "script_params=${script_params}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "stage=${stage}" >> $GITHUB_OUTPUT
+          echo "set_as_main=${{ env.SET_AS_MAIN }}" >> $GITHUB_OUTPUT
 
       - name: Create and switch to bump branch
         run: |
@@ -100,9 +107,37 @@ jobs:
       - name: Make version bump changes
         run: |
           echo "Running bump script"
-          bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
+          script_params=()
+          version="${{ steps.vars.outputs.version }}"
+          stage="${{ steps.vars.outputs.stage }}"
+          set_as_main="${{ steps.vars.outputs.set_as_main }}"
+
+          if [[ -n "$version" ]]; then
+            script_params+=("--version" "$version")
+          fi
+
+          if [[ -n "$stage" ]]; then
+            script_params+=("--stage" "$stage")
+          fi
+
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params+=("--set-as-main")
+          fi
+
+          bash "${{ env.BUMP_SCRIPT_PATH }}" "${script_params[@]}"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected; skipping PR creation."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
@@ -110,6 +145,7 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -122,6 +158,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
@@ -130,6 +167,6 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          echo "PR: ${{ steps.create_pr.outputs.pull_request_url || 'N/A (no changes)' }}"
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -167,6 +167,10 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url || 'N/A (no changes)' }}"
+          if [[ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]]; then
+             echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+             echo "No file changes from bumper (no PR created)."
+          fi
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
         description: Source code reference (branch, tag or commit SHA)
-        default: 5.0.0
+        default: main
   workflow_dispatch:
     inputs:
       reference:

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,7 +7,7 @@ This script automates the process of updating the version and stage in the Wazuh
 ### Usage
 
 ```bash
-./repository_bumper.sh --version VERSION --stage STAGE [--help]
+./repository_bumper.sh --version VERSION --stage STAGE [--set-as-main] [--help]
 ```
 
 #### Parameters
@@ -18,6 +18,9 @@ This script automates the process of updating the version and stage in the Wazuh
 - `--stage STAGE`
   Specifies the stage (e.g., `alpha0`, `beta1`, `rc2`, etc.).
 
+- `--set-as-main`
+  Enables main branch mode. The script updates version values but keeps branch references pointing to `main`.
+
 - `--help`
   Shows help and exits.
 
@@ -26,6 +29,7 @@ This script automates the process of updating the version and stage in the Wazuh
 ```bash
 ./repository_bumper.sh --version 4.6.0 --stage alpha0
 ./repository_bumper.sh --version 4.6.0 --stage beta1
+./repository_bumper.sh --version 5.0.0 --stage beta1 --set-as-main
 ```
 
 ### What does the script do?
@@ -39,7 +43,10 @@ This script automates the process of updating the version and stage in the Wazuh
    - `VERSION.json`: Changes the `version` and `stage` fields.
    - `package.json`: Changes the `version` and `revision` fields inside the `wazuh` object.
    - `.github/workflows/manual-build.yml`: Updates the default value of the `reference` input if applicable.
-5. **Logs all actions** to a log file in the `tools` directory.
+5. **Handles branch reference replacements**:
+   - If `--set-as-main` is used, `skip_urls` is set to `yes` and branch references to `main` are preserved.
+   - Otherwise, `skip_urls` is set to `no` and branch reference defaults set to `main` are replaced with the target version in supported workflow files.
+6. **Logs all actions** to a log file in the `tools` directory.
 
 ### Notes
 
@@ -52,6 +59,9 @@ This script automates the process of updating the version and stage in the Wazuh
 - `VERSION.json`
 - `package.json`
 - `.github/workflows/manual-build.yml`
+- `.github/workflows/dev-environment.yml`
+- `.github/workflows/5_builderprecompiled_base-dev-environment.yml`
+- `.github/workflows/5_builderpackage_security_plugin.yml`
 
 ### Log
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -341,67 +341,26 @@ update_manual_build_workflow() {
 
 update_branch_reference_defaults() {
   if [[ "$skip_urls" == "yes" ]]; then
-    log "Main branch mode enabled: branch references remain pointing to main."
-    return
+    log "skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged"
+    return 0
   fi
-
-  log "Freeze mode enabled: replacing branch references main -> ${VERSION}."
 
   local bump_string="$VERSION"
-  local workflow_file=""
-  local tmp_file=""
-
-  workflow_file="${REPO_PATH}/.github/workflows/manual-build.yml"
-  if [ -f "$workflow_file" ]; then
-    tmp_file=$(mktemp)
-    cp "$workflow_file" "$tmp_file"
-    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
-    if cmp -s "$workflow_file" "$tmp_file"; then
-      log "No branch default 'main' match found in $workflow_file"
-    else
-      log "Updated branch references in $workflow_file"
+  local files=(
+    "${REPO_PATH}/.github/workflows/manual-build.yml"
+    "${REPO_PATH}/.github/workflows/dev-environment.yml"
+    "${REPO_PATH}/.github/workflows/5_builderpackage_security_plugin.yml"
+    "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
+  )
+  local f
+  for f in "${files[@]}"; do
+    if [ ! -f "$f" ]; then
+      log "WARNING: $f not found. Skipping main→${bump_string} default update."
+      continue
     fi
-    rm -f "$tmp_file"
-  fi
-
-  workflow_file="${REPO_PATH}/.github/workflows/dev-environment.yml"
-  if [ -f "$workflow_file" ]; then
-    tmp_file=$(mktemp)
-    cp "$workflow_file" "$tmp_file"
-    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
-    if cmp -s "$workflow_file" "$tmp_file"; then
-      log "No branch default 'main' match found in $workflow_file"
-    else
-      log "Updated branch references in $workflow_file"
-    fi
-    rm -f "$tmp_file"
-  fi
-
-  workflow_file="${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
-  if [ -f "$workflow_file" ]; then
-    tmp_file=$(mktemp)
-    cp "$workflow_file" "$tmp_file"
-    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
-    if cmp -s "$workflow_file" "$tmp_file"; then
-      log "No branch default 'main' match found in $workflow_file"
-    else
-      log "Updated branch references in $workflow_file"
-    fi
-    rm -f "$tmp_file"
-  fi
-
-  workflow_file="${REPO_PATH}/.github/workflows/5_builderpackage_security_plugin.yml"
-  if [ -f "$workflow_file" ]; then
-    tmp_file=$(mktemp)
-    cp "$workflow_file" "$tmp_file"
-    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
-    if cmp -s "$workflow_file" "$tmp_file"; then
-      log "No branch default 'main' match found in $workflow_file"
-    else
-      log "Updated branch references in $workflow_file"
-    fi
-    rm -f "$tmp_file"
-  fi
+    log "Replacing default: main with default: ${bump_string} in $f (where applicable)"
+    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*\)main\([[:space:]]*\)$/\1${bump_string}\2/" "$f"
+  done
 }
 
 # --- Main Execution ---

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -14,7 +14,8 @@ VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
 CURRENT_VERSION=""
-
+set_as_main=""
+skip_urls="no"
 # --- Helper Functions ---
 
 # Function to log messages
@@ -41,11 +42,12 @@ sed_inplace() {
 
 # Function to show usage
 usage() {
-  echo "Usage: $0 --version VERSION --stage STAGE [--help]"
+  echo "Usage: $0 --version VERSION --stage STAGE [--set-as-main] [--help]"
   echo ""
   echo "Parameters:"
   echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
   echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
+  echo "  --set-as-main       Keep branch references pointing to main"
   echo "  --help              Display this help message"
   echo ""
   echo "Example:"
@@ -67,6 +69,10 @@ parse_arguments() {
       STAGE="$2"
       shift 2
       ;;
+    --set-as-main)
+      set_as_main="yes"
+      shift 1
+      ;;
     --help)
       usage
       exit 0
@@ -78,6 +84,12 @@ parse_arguments() {
       ;;
     esac
   done
+
+  if [[ -n "$set_as_main" ]]; then
+    skip_urls="yes"
+  else
+    skip_urls="no"
+  fi
 }
 
 # Function to validate input parameters
@@ -327,6 +339,71 @@ update_manual_build_workflow() {
 
 }
 
+update_branch_reference_defaults() {
+  if [[ "$skip_urls" == "yes" ]]; then
+    log "Main branch mode enabled: branch references remain pointing to main."
+    return
+  fi
+
+  log "Freeze mode enabled: replacing branch references main -> ${VERSION}."
+
+  local bump_string="$VERSION"
+  local workflow_file=""
+  local tmp_file=""
+
+  workflow_file="${REPO_PATH}/.github/workflows/manual-build.yml"
+  if [ -f "$workflow_file" ]; then
+    tmp_file=$(mktemp)
+    cp "$workflow_file" "$tmp_file"
+    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
+    if cmp -s "$workflow_file" "$tmp_file"; then
+      log "No branch default 'main' match found in $workflow_file"
+    else
+      log "Updated branch references in $workflow_file"
+    fi
+    rm -f "$tmp_file"
+  fi
+
+  workflow_file="${REPO_PATH}/.github/workflows/dev-environment.yml"
+  if [ -f "$workflow_file" ]; then
+    tmp_file=$(mktemp)
+    cp "$workflow_file" "$tmp_file"
+    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
+    if cmp -s "$workflow_file" "$tmp_file"; then
+      log "No branch default 'main' match found in $workflow_file"
+    else
+      log "Updated branch references in $workflow_file"
+    fi
+    rm -f "$tmp_file"
+  fi
+
+  workflow_file="${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
+  if [ -f "$workflow_file" ]; then
+    tmp_file=$(mktemp)
+    cp "$workflow_file" "$tmp_file"
+    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
+    if cmp -s "$workflow_file" "$tmp_file"; then
+      log "No branch default 'main' match found in $workflow_file"
+    else
+      log "Updated branch references in $workflow_file"
+    fi
+    rm -f "$tmp_file"
+  fi
+
+  workflow_file="${REPO_PATH}/.github/workflows/5_builderpackage_security_plugin.yml"
+  if [ -f "$workflow_file" ]; then
+    tmp_file=$(mktemp)
+    cp "$workflow_file" "$tmp_file"
+    sed_inplace "s/^\([[:space:]]*default:[[:space:]]*['\"]\?\)main\(['\"]\?[[:space:]]*\)$/\1${bump_string}\2/" "$workflow_file"
+    if cmp -s "$workflow_file" "$tmp_file"; then
+      log "No branch default 'main' match found in $workflow_file"
+    else
+      log "Updated branch references in $workflow_file"
+    fi
+    rm -f "$tmp_file"
+  fi
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -353,12 +430,19 @@ main() {
   # Compare versions and determine revision
   compare_versions_and_set_revision
 
+  if [[ "$skip_urls" == "yes" ]]; then
+    log "Main branch mode enabled: version values will be updated and branch references will remain pointing to main."
+  else
+    log "Freeze mode enabled: version values and branch references will be updated."
+  fi
+
   # Start file modifications
   log "Starting file modifications..."
 
   update_root_version_json
   update_package_json
   update_manual_build_workflow
+  update_branch_reference_defaults
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"


### PR DESCRIPTION
### Description
This PR adds support for the --set-as-main flag in this repository's bumper files as part of the two-step version bump flow from main.

If the --set-as-main flag is not set, it will update the references to main branch to the specified version, if its set, it will skip that step.

### Issues Resolved
- **Issue:** https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/496

### Evidence:

<details><summary>Running: <code>./tools/repository_bumper.sh  --version 5.1.0 --stage alpha0 </code></summary>
<p>

```bash
wazuh-security-dashboards-plugin/tools change/496-add-set-as-main-flag-support-to-repository-bumper-wazuh-security-dashboards-plugin ❯ ./repository_bumper.sh  --version 5.1.0 --stage alpha0
[2026-03-30 09:52:29] Starting repository bump process
[2026-03-30 09:52:29] Repository path: /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin
[2026-03-30 09:52:29] Version: 5.1.0
[2026-03-30 09:52:29] Stage: alpha0
[2026-03-30 09:52:29] Attempting to extract current version from /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json using sed...
[2026-03-30 09:52:29] Successfully extracted version using sed: 5.0.0
[2026-03-30 09:52:29] Current version detected in VERSION.json: 5.0.0
[2026-03-30 09:52:29] Attempting to extract current stage from /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json using sed...
[2026-03-30 09:52:29] Successfully extracted stage using sed: alpha0
[2026-03-30 09:52:29] Current stage detected in VERSION.json: alpha0
[2026-03-30 09:52:29] Attempting to extract current revision from /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json using sed...
[2026-03-30 09:52:29] Successfully extracted revision using sed: 00
[2026-03-30 09:52:29] Current revision detected in package.json: 00
[2026-03-30 09:52:29] Default revision set to: 00
[2026-03-30 09:52:29] Comparing new version (5.1.0) with current version (5.0.0)...
[2026-03-30 09:52:29] Version check passed: New version (5.1.0) is greater than current version (5.0.0) (Minor increased).
[2026-03-30 09:52:29] Final revision determined: 00
[2026-03-30 09:52:29] Freeze mode enabled: version values and branch references will be updated.
[2026-03-30 09:52:29] Starting file modifications...
[2026-03-30 09:52:29] Processing /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json
[2026-03-30 09:52:29] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json with new version: 5.1.0 and stage: alpha0
[2026-03-30 09:52:29] Processing /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json
[2026-03-30 09:52:29] Attempting to update version to 5.1.0 within 'wazuh' object in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json
[2026-03-30 09:52:29] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json with new version: 5.1.0 and revision: 00
[2026-03-30 09:52:29] Processing /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml
[2026-03-30 09:52:29] Attempting to update default reference to 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml
[2026-03-30 09:52:29] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml with new default reference: 5.1.0
[2026-03-30 09:52:29] Updating manual build workflow...
[2026-03-30 09:52:29] Freeze mode enabled: replacing branch references main -> 5.1.0.
[2026-03-30 09:52:29] Updated branch references in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml
[2026-03-30 09:52:29] Updated branch references in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/dev-environment.yml
[2026-03-30 09:52:29] Updated branch references in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/5_builderprecompiled_base-dev-environment.yml
[2026-03-30 09:52:29] Updated branch references in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/5_builderpackage_security_plugin.yml
[2026-03-30 09:52:29] File modifications completed.
[2026-03-30 09:52:29] Repository bump completed successfully. Log file: /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/tools/repository_bumper_2026-03-30_09-52-29-393.log
```

</p>
</details> 

<details><summary>Running: <code>./tools/repository_bumper.sh  --version 5.1.0 --stage alpha0 --set-as-main</code></summary>
<p>

```bash
wazuh-security-dashboards-plugin/tools change/496-add-set-as-main-flag-support-to-repository-bumper-wazuh-security-dashboards-plugin ❯ ./repository_bump
er.sh  --version 5.1.0 --stage alpha0 --set-as-main
[2026-03-30 09:56:03] Starting repository bump process
[2026-03-30 09:56:03] Repository path: /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin
[2026-03-30 09:56:03] Version: 5.1.0
[2026-03-30 09:56:03] Stage: alpha0
[2026-03-30 09:56:03] Attempting to extract current version from /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json using sed...
[2026-03-30 09:56:03] Successfully extracted version using sed: 5.0.0
[2026-03-30 09:56:03] Current version detected in VERSION.json: 5.0.0
[2026-03-30 09:56:03] Attempting to extract current stage from /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json using sed...
[2026-03-30 09:56:03] Successfully extracted stage using sed: alpha0
[2026-03-30 09:56:03] Current stage detected in VERSION.json: alpha0
[2026-03-30 09:56:03] Attempting to extract current revision from /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json using sed...
[2026-03-30 09:56:03] Successfully extracted revision using sed: 00
[2026-03-30 09:56:03] Current revision detected in package.json: 00
[2026-03-30 09:56:03] Default revision set to: 00
[2026-03-30 09:56:03] Comparing new version (5.1.0) with current version (5.0.0)...
[2026-03-30 09:56:03] Version check passed: New version (5.1.0) is greater than current version (5.0.0) (Minor increased).
[2026-03-30 09:56:03] Final revision determined: 00
[2026-03-30 09:56:03] Main branch mode enabled: version values will be updated and branch references will remain pointing to main.
[2026-03-30 09:56:03] Starting file modifications...
[2026-03-30 09:56:03] Processing /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json
[2026-03-30 09:56:03] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/VERSION.json with new version: 5.1.0 and stage: alpha0
[2026-03-30 09:56:03] Processing /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json
[2026-03-30 09:56:03] Attempting to update version to 5.1.0 within 'wazuh' object in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json
[2026-03-30 09:56:03] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/package.json with new version: 5.1.0 and revision: 00
[2026-03-30 09:56:03] Processing /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml
[2026-03-30 09:56:03] Attempting to update default reference to 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml
[2026-03-30 09:56:03] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml with new default reference: 5.1.0
[2026-03-30 09:56:03] Updating manual build workflow...
[2026-03-30 09:56:03] Main branch mode enabled: branch references remain pointing to main.
[2026-03-30 09:56:03] File modifications completed.
[2026-03-30 09:56:03] Repository bump completed successfully. Log file: /home/runner/Documents/Wazuh/repos/wazuh-security-dashboards-plugin/tools/repository_bumper_2026-03-30_09-56-03-907.log

```

</p>
</details> 

### Testing
- Try running the commands specified in evidence and look at the output log created.

### Check List
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff