### PR TITLE
Support Revert bump functionality in wazuh-security-dashboard-plugin

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: false
+      revert:
+        description: 'Set to true to revert the bump changes applied for this issue'
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   bump:
@@ -72,9 +77,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Using workflow-specific GITHUB_TOKEN because currently CI_WAZUHCI_BUMPER_TOKEN
-          # doesn't have all the necessary permissions
           token: ${{ env.GH_TOKEN }}
+          fetch-depth: 0
 
       - name: Determine branch name
         id: vars
@@ -87,6 +91,7 @@ jobs:
           stage=${{ env.STAGE }}
 
           # Both version and stage provided
+          script_params=""
           if [[ -n "$version" && -n "$stage" ]]; then
             script_params="--version ${version} --stage ${stage}"
           elif [[ -z "$version" && -n "$stage" ]]; then
@@ -94,7 +99,13 @@ jobs:
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
-          BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
+          if [[ "${{ inputs.revert }}" == "true" ]]; then
+            BRANCH_NAME="enhancement/wqa${issue_number}-revert-bump-${{ github.ref_name }}"
+            echo "pr_title=Revert bump ${{ github.ref_name }} branch" >> $GITHUB_OUTPUT
+          else
+            BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
+            echo "pr_title=Bump ${{ github.ref_name }} branch" >> $GITHUB_OUTPUT
+          fi
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "stage=${stage}" >> $GITHUB_OUTPUT
@@ -105,6 +116,7 @@ jobs:
           git checkout -b ${{ steps.vars.outputs.branch_name }}
 
       - name: Make version bump changes
+        if: inputs.revert != true
         run: |
           echo "Running bump script"
           script_params=()
@@ -129,27 +141,67 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
-          if git diff --quiet; then
+          if [[ "${{ inputs.revert }}" == "true" ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          elif git diff --quiet; then
             echo "No changes detected; skipping PR creation."
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push changes
-        if: steps.check_changes.outputs.has_changes == 'true'
+      - name: Commit changes (Bump)
+        if: inputs.revert != true && steps.check_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
+
+      - name: Revert references (Revert)
+        id: revert_step
+        if: inputs.revert == true
+        run: |
+          ISSUE_NUMBER=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
+
+          BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
+
+          PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+            echo "Error: The original PR for the bump was not found"
+            echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
+            exit 1
+          fi
+
+          echo "Original PR found: #$PR_NUMBER"
+
+          MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
+
+          git revert -m 1 $MERGE_COMMIT --no-commit
+
+          git checkout HEAD -- VERSION.json 2>/dev/null || true
+          git checkout HEAD -- CHANGELOG.md 2>/dev/null || true
+          git checkout HEAD -- package.json 2>/dev/null || true
+
+          if git diff --staged --quiet; then
+            echo "No references to revert. Skipping commit."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "feat: revert ${{ github.ref_name }} references"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push changes
+        if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        run: |
           git push origin ${{ steps.vars.outputs.branch_name }}
 
       - name: Create pull request
         id: create_pr
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
-            --title "Bump ${{ github.ref_name }} branch" \
+            --title "${{ steps.vars.outputs.pr_title }}" \
             --body "Issue: ${{ inputs.issue-link }}" \
             --base ${{ github.ref_name }} \
             --head ${{ steps.vars.outputs.branch_name }})
@@ -158,12 +210,12 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
 
       - name: Show logs
+        if: inputs.revert != true
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
@@ -174,3 +226,16 @@ jobs:
           fi
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log
+
+      - name: Show revert logs
+        if: inputs.revert == true
+        run: |
+          echo "Revert bump complete."
+          echo "Branch: ${{ steps.vars.outputs.branch_name }}"
+          if [[ "${{ steps.revert_step.outputs.has_changes }}" == "true" ]]; then
+             echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+             echo "No references to revert (no PR created)."
+          fi
+          echo "Revert bumper scripts logs:"
+          cat ${BUMP_LOG_PATH}/repository_bumper*log || true

--- a/tools/README.md
+++ b/tools/README.md
@@ -40,6 +40,7 @@ This script automates the process of updating the version and stage in the Wazuh
    - If the version changes (major, minor, or patch), it resets the revision to `00`.
    - If the version is the same, it increments the revision.
 4. **Updates the files**:
+   - `CHANGELOG.md`: Changes the version and revision in the version header.
    - `VERSION.json`: Changes the `version` and `stage` fields.
    - `package.json`: Changes the `version` and `revision` fields inside the `wazuh` object.
    - `.github/workflows/manual-build.yml`: Updates the default value of the `reference` input if applicable.
@@ -56,6 +57,7 @@ This script automates the process of updating the version and stage in the Wazuh
 
 ### Affected files
 
+- `CHANGELOG.md`
 - `VERSION.json`
 - `package.json`
 - `.github/workflows/manual-build.yml`

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -10,6 +10,7 @@ SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
 DATE_TIME=$(date "+%Y-%m-%d_%H-%M-%S-%3N")
 LOG_FILE="${SCRIPT_PATH}/repository_bumper_${DATE_TIME}.log"
+PACKAGE_JSON="${REPO_PATH}/package.json"
 VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
@@ -27,16 +28,35 @@ log() {
 
 # Function to handle sed -i in a portable way (macOS vs Linux)
 sed_inplace() {
-  local pattern="$1"
-  local file="$2"
+  local options=""
+  local pattern=""
+  local file=""
 
-  # Detect OS type
+  # Parse arguments to handle options like -E
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -E|-r)
+        options="$options $1"
+        shift
+        ;;
+      *)
+        if [ -z "$pattern" ]; then
+          pattern="$1"
+        elif [ -z "$file" ]; then
+          file="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  # Detect OS and use appropriate sed syntax
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS - requires empty string for backup extension
-    sed -i '' "$pattern" "$file"
+    # macOS (BSD sed) requires empty string after -i
+    sed -i '' $options "$pattern" "$file"
   else
-    # Linux and other Unix systems
-    sed -i "$pattern" "$file"
+    # Linux (GNU sed) doesn't require anything after -i
+    sed -i $options "$pattern" "$file"
   fi
 }
 
@@ -156,7 +176,6 @@ pre_update_checks() {
   log "Current stage detected in VERSION.json: $CURRENT_STAGE"
 
   # Attempt to extract current revision from package.json using sed
-  local PACKAGE_JSON="${REPO_PATH}/package.json"
   log "Attempting to extract current revision from $PACKAGE_JSON using sed..."
   CURRENT_REVISION=$(sed -n '/"wazuh": {/,/}/ s/^[[:space:]]*"revision"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
 
@@ -268,7 +287,6 @@ update_root_version_json() {
 }
 
 update_package_json() {
-  local PACKAGE_JSON="${REPO_PATH}/package.json" # Define path, assuming it's the main one
   if [ -f "$PACKAGE_JSON" ]; then
     log "Processing $PACKAGE_JSON"
     local modified=false
@@ -363,6 +381,62 @@ update_branch_reference_defaults() {
   done
 }
 
+# Function to update CHANGELOG.md
+update_changelog() {
+  log "Updating CHANGELOG.md..."
+  local changelog_file="${REPO_PATH}/CHANGELOG.md"
+
+  # Extract OpenSearch Dashboards version from package.json
+  # Attempt to extract OpenSearch Dashboards version using sed (WARNING: Fragile!)
+  # This assumes "pluginPlatform": { ... "version": "x.y.z" ... } structure
+  # It looks for the block starting with "pluginPlatform": { and ending with }
+  # Within that block, it finds the line starting with "version": "..." and extracts the value.
+  # This is significantly less reliable than using jq.
+  log "Attempting to extract .version from $PACKAGE_JSON using sed (Note: This is fragile)"
+  # Extract OpenSearch Dashboards version from package.json (first occurrence of "version")
+  OPENSEARCH_VERSION=$(sed -n '/"opensearchDashboards": {/,/}/ s/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p' "$PACKAGE_JSON" | head -n 1)
+  if [ -z "$OPENSEARCH_VERSION" ] || [ "$OPENSEARCH_VERSION" == "null" ]; then
+    log "ERROR: Could not extract pluginPlatform.version from $PACKAGE_JSON for changelog"
+    exit 1
+  fi
+  log "Detected OpenSearch Dashboards version for changelog: $OPENSEARCH_VERSION"
+
+  # Construct the new changelog entry
+  # Note: Using printf for better handling of newlines and potential special characters
+  # Use the calculated REVISION variable here
+  # Prepare the header to search for
+  local changelog_header="## Wazuh dashboard v${VERSION} - OpenSearch Dashboards ${OPENSEARCH_VERSION} - Revision "
+  local changelog_header_regex="^${changelog_header}[0-9]+"
+
+  # Check if an entry for this version and OpenSearch version already exists
+  if grep -qE "$changelog_header_regex" "$changelog_file"; then
+    if [ -n "$STAGE" ]; then
+      log "Changelog entry for this version and OpenSearch Dashboards version exists. Updating revision only."
+      # Use sed to update only the revision number in the header
+       sed_inplace -E "s|(${changelog_header_regex})|${changelog_header}${REVISION}|" "$changelog_file" &&
+        log "CHANGELOG.md revision updated successfully." || {
+        log "ERROR: Failed to update revision in $changelog_file"
+        exit 1
+      }
+    fi
+  else
+    log "No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry."
+
+   # Create the new entry directly in the changelog using sed
+    local temp_file=$(mktemp)
+    head -n 4 "$changelog_file" >"$temp_file"
+    printf "## Wazuh dashboard v%s - OpenSearch Dashboards %s - Revision %s\n\n### Added\n\n- Support for Wazuh %s\n\n" "$VERSION" "$OPENSEARCH_VERSION" "$REVISION" "$VERSION" >>"$temp_file"
+    tail -n +5 "$changelog_file" >>"$temp_file"
+
+    mv "$temp_file" "$changelog_file" || {
+      log "ERROR: Failed to update $changelog_file"
+      rm -f "$temp_file" # Clean up temp file on error
+      exit 1
+    }
+    log "CHANGELOG.md updated successfully."
+  fi
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -401,6 +475,7 @@ main() {
   update_root_version_json
   update_package_json
   update_manual_build_workflow
+  update_changelog
   update_branch_reference_defaults
 
   log "File modifications completed."


### PR DESCRIPTION
### Description
Automates the final stage-bump revert flow in both bumper workflows by adding a revert mode that selectively reverts bump reference changes while preserving core version files (e.g. VERSION.json, CHANGELOG.md), and skips PR creation when no effective revert changes remain.

Side changes:
- Add ability to bump the CHANGELOG.md file

### Issues Resolved
- **Closes**: https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/515

### Evidence

1. Trigger the workflow on a branch with `revert=false` normal bump script runs, references, and version values updated → PR created correctly: https://github.com/Ripdiegozz/wazuh-security-dashboards-plugin/actions/runs/25013809743

2. Merge the previous PR and trigger the workflow on the same branch with `revert=true` and `issue-link` pointing to the previous execution's issue, script bypassed, `gh` cli finds the PR, git reverts the commit, core version files are preserved → new Revert PR created: https://github.com/Ripdiegozz/wazuh-security-dashboards-plugin/actions/runs/25017249389

3. Verify that triggering `revert=true` when only `VERSION.json` was updated in the original bump results in a clean exit (no empty PR created):
    - Bumper only changes `VERSION.json`: https://github.com/Ripdiegozz/wazuh-security-dashboards-plugin/actions/runs/25019370706
    - `revert=true` results in a clean exit: https://github.com/Ripdiegozz/wazuh-security-dashboards-plugin/actions/runs/25019720148

### Check List
- [X] Commits are signed per the DCO using --signoff