### PR TITLE
Updates CI runner to ubuntu-26.04

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Deploy and run command
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

This PR updates the Ubuntu version used into GHA workflows to latest LTS version, 26.04

### Issues Resolved

- https://github.com/wazuh/wazuh/issues/35755