### PR TITLE
Fix tag references on bump when --tag is provided

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -14,6 +14,11 @@ on:
         default: ''
         required: false
         type: string
+      tag:
+        description: 'Change branches references to tag-like references (e.g. v4.12.0-alpha7)'
+        default: false
+        required: false
+        type: boolean
       issue-link:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
@@ -85,17 +90,26 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          TAG: ${{ inputs.tag }}
           SET_AS_MAIN: ${{ inputs.set_as_main }}
         run: |
+          script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
-
+          tag=${{ env.TAG }}
+          set_as_main=${{ env.SET_AS_MAIN }}
+          
           # Both version and stage provided
-          script_params=""
-          if [[ -n "$version" && -n "$stage" ]]; then
+          if [[ -n "$version" && -n "$stage" && "$tag" != "true" ]]; then
             script_params="--version ${version} --stage ${stage}"
-          elif [[ -z "$version" && -n "$stage" ]]; then
-            script_params="--stage ${stage}"
+          elif [[ -z "$version" && -n "$stage" && "$tag" == "true" ]]; then
+            script_params="--stage ${stage} --tag"
+          elif [[ -z "$version" && -z "$stage" && "$tag" == "true" ]]; then
+            script_params="--tag"
+          fi
+
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params="${script_params} --set-as-main"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
@@ -107,9 +121,7 @@ jobs:
             echo "pr_title=Bump ${{ github.ref_name }} branch" >> $GITHUB_OUTPUT
           fi
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "version=${version}" >> $GITHUB_OUTPUT
-          echo "stage=${stage}" >> $GITHUB_OUTPUT
-          echo "set_as_main=${{ env.SET_AS_MAIN }}" >> $GITHUB_OUTPUT
+          echo "script_params=${script_params}" >> $GITHUB_OUTPUT
 
       - name: Create and switch to bump branch
         run: |
@@ -119,24 +131,7 @@ jobs:
         if: inputs.revert != true
         run: |
           echo "Running bump script"
-          script_params=()
-          version="${{ steps.vars.outputs.version }}"
-          stage="${{ steps.vars.outputs.stage }}"
-          set_as_main="${{ steps.vars.outputs.set_as_main }}"
-
-          if [[ -n "$version" ]]; then
-            script_params+=("--version" "$version")
-          fi
-
-          if [[ -n "$stage" ]]; then
-            script_params+=("--stage" "$stage")
-          fi
-
-          if [[ "$set_as_main" == "true" ]]; then
-            script_params+=("--set-as-main")
-          fi
-
-          bash "${{ env.BUMP_SCRIPT_PATH }}" "${script_params[@]}"
+          bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
       - name: Check for changes
         id: check_changes
@@ -148,6 +143,8 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes detected"
+            git status --porcelain
           fi
 
       - name: Commit changes (Bump)

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -14,6 +14,7 @@ PACKAGE_JSON="${REPO_PATH}/package.json"
 VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
+TAG=false
 CURRENT_VERSION=""
 set_as_main=""
 skip_urls="no"
@@ -93,6 +94,10 @@ parse_arguments() {
       set_as_main="yes"
       shift 1
       ;;
+    --tag)
+      TAG=true
+      shift
+      ;;
     --help)
       usage
       exit 0
@@ -114,21 +119,24 @@ parse_arguments() {
 
 # Function to validate input parameters
 validate_input() {
-  if [ -z "$VERSION" ]; then
-    log "ERROR: Version parameter is required"
+  if [ -z "$VERSION" ] && [ "$TAG" != true ]; then
+    log "ERROR: --version is required unless --tag is set"
     usage
     exit 1
   fi
-  if [ -z "$STAGE" ]; then
-    log "ERROR: Stage parameter is required"
+
+  if [ -z "$STAGE" ] && [ "$TAG" != true ]; then
+    log "ERROR: --stage is required unless --tag is set"
     usage
     exit 1
   fi
-  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+
+  if [ -n "$VERSION" ] && ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     log "ERROR: Version must be in the format x.y.z (e.g., 4.6.0)"
     exit 1
   fi
-  if ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
+
+  if [ -n "$STAGE" ] && ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
     log "ERROR: Stage must be alphanumeric (e.g., alpha0, beta1, rc2)"
     exit 1
   fi
@@ -323,47 +331,13 @@ update_package_json() {
   fi
 }
 
-update_manual_build_workflow() {
-  local WORKFLOW_FILE="${REPO_PATH}/.github/workflows/manual-build.yml"
-  if [ -f "$WORKFLOW_FILE" ]; then
-    log "Processing $WORKFLOW_FILE"
-    local modified=false
-    # Update version in manual build workflow
-    # on:
-    #   workflow_call:
-    #     inputs:
-    #       reference:
-    #         required: true
-    #         type: string
-    #         description: Source code reference (branch, tag or commit SHA)
-    #         default: 5.0.0
-    # Update the default value for the reference input
-    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
-      log "Attempting to update default reference to $VERSION in $WORKFLOW_FILE"
-      # Note: This sed command assumes a specific formatting and might be fragile.
-      # It looks for the line starting with "default:" and replaces the version value
-      # Ensure to escape special characters if necessary
-      sed_inplace "s/^\([[:space:]]*default:[[:space:]]*\)$CURRENT_VERSION/\1$VERSION/" "$WORKFLOW_FILE"
-      modified=true
-    fi
-
-    if [[ $modified == true ]]; then
-      log "Successfully updated $WORKFLOW_FILE with new default reference: $VERSION"
-    fi
-  else
-    log "WARNING: $WORKFLOW_FILE not found. Skipping update."
-  fi
-  log "Updating manual build workflow..."
-
-}
-
 update_branch_reference_defaults() {
   if [[ "$skip_urls" == "yes" ]]; then
     log "skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged"
     return 0
   fi
 
-  local bump_string="$VERSION"
+  local bump_string="$GIT_REF_REPLACEMENT"
   local files=(
     "${REPO_PATH}/.github/workflows/manual-build.yml"
     "${REPO_PATH}/.github/workflows/dev-environment.yml"
@@ -437,6 +411,20 @@ update_changelog() {
   fi
 }
 
+get_git_ref_replacement(){
+  local replacement
+  if [ "$TAG" = true ]; then
+    replacement="v${VERSION}"
+    if [ -n "$STAGE" ]; then
+      replacement+="-${STAGE}"
+    fi
+  else
+    replacement="${VERSION}"
+  fi
+
+  GIT_REF_REPLACEMENT="$replacement"
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -459,6 +447,9 @@ main() {
 
   # Perform pre-update checks
   pre_update_checks
+  if [ -z "$VERSION" ]; then
+    VERSION=$CURRENT_VERSION # If no version provided, use current version
+  fi
 
   # Compare versions and determine revision
   compare_versions_and_set_revision
@@ -469,12 +460,13 @@ main() {
     log "Freeze mode enabled: version values and branch references will be updated."
   fi
 
+  get_git_ref_replacement
+
   # Start file modifications
   log "Starting file modifications..."
 
   update_root_version_json
   update_package_json
-  update_manual_build_workflow
   update_changelog
   update_branch_reference_defaults
 


### PR DESCRIPTION
### Description

This pull request fixes the git references in some files on bump when --tag is provided.

Side changes:
- Add the `--tag` flag to the bumper script

### Issues Resolved

https://github.com/wazuh/wazuh-dashboard/issues/1295

### Evidences

```diff
diff --git a/.github/workflows/5_builderpackage_security_plugin.yml b/.github/workflows/5_builderpackage_security_plugin.yml
index 813da00..ed09df7 100644
--- a/.github/workflows/5_builderpackage_security_plugin.yml
+++ b/.github/workflows/5_builderpackage_security_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Source code reference (branch, tag or commit SHA)
-        default: main
+        default: v5.0.0-beta3
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Source code reference (branch, tag or commit SHA)
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index b564ae4..1f588ee 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -20,7 +20,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true
diff --git a/.github/workflows/dev-environment.yml b/.github/workflows/dev-environment.yml
index 4517df1..c4bd783 100644
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -12,7 +12,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true
diff --git a/.github/workflows/manual-build.yml b/.github/workflows/manual-build.yml
index 86cfb0b..dcb9c4e 100644
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -12,13 +12,13 @@ on:
         required: true
         type: string
         description: Source code reference (branch, tag or commit SHA)
-        default: main
+        default: v5.0.0-beta3
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0-beta3
         description: Source code reference (branch, tag or commit SHA)
 
 jobs:
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 404e766..f143980 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Wazuh dashboard security plugin project will be documented in this file.
 
-## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 02
+## Wazuh dashboard v5.0.0 - OpenSearch Dashboards 3.6.0 - Revision 03
 
 ### Added
 
diff --git a/VERSION.json b/VERSION.json
index 0533024..a57868a 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "5.0.0",
-  "stage": "beta2"
+  "stage": "beta3"
 }
diff --git a/package.json b/package.json
index 1ec33dd..e5f35d8 100644
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "wazuh": {
     "version": "5.0.0",
-    "revision": "02"
+    "revision": "03"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",
```

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## Other

| Test | Result |
| --- |  --- |
| Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff` | :black_circle: |

**Details**
<details>
<summary>:black_circle: Run `./repository_bumper.sh --tag --stage beta3`, then check the references to `main` were changed to the tag `git --no-pager diff`</summary>

</details>

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff
