### PR TITLE
Fix wrong editions on bumper for tag flag

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -258,9 +258,15 @@ compare_versions_and_set_revision() {
         # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
         local current_revision_int=$((10#$current_revision_val))
         local new_revision_int=$((current_revision_int + 1))
-        # Format back to two digits with leading zero
-        REVISION=$(printf "%02d" "$new_revision_int")
-        log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        if [ -n "$STAGE" ] && [ "$STAGE" != "$CURRENT_STAGE" ]; then
+          # Format back to two digits with leading zero
+          log "Incrementing revision."
+          REVISION=$(printf "%02d" "$new_revision_int")
+          log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        else
+          REVISION=$(printf "%02d" "$current_revision_int")
+          log "Current revision: $current_revision_val."
+        fi
       fi
     fi
   fi
@@ -281,7 +287,7 @@ update_root_version_json() {
     fi
 
     # Update stage in VERSION.json
-    if [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
+    if [ -n "$STAGE" ] && [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
       sed_inplace "s/^[[:space:]]*\"stage\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
       modified=true
     fi


### PR DESCRIPTION
### Description
This pull request fixes wrong editions on bumper for --tag flag.

### Issues Resolved
#611 

### Evidence
The current version is: `5.0.0`
The current stage is: `beta3`

<details><summary> <code>bash tools/repository_bumper.sh --tag</code> </summary>

**Output:**

```shell
[2026-06-10 12:16:54] Starting repository bump process
[2026-06-10 12:16:54] Repository path: /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin
[2026-06-10 12:16:54] Version: 
[2026-06-10 12:16:54] Stage: 
[2026-06-10 12:16:54] Attempting to extract current version from /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/VERSION.json using sed...
[2026-06-10 12:16:54] Successfully extracted version using sed: 5.0.0
[2026-06-10 12:16:54] Current version detected in VERSION.json: 5.0.0
[2026-06-10 12:16:54] Attempting to extract current stage from /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/VERSION.json using sed...
[2026-06-10 12:16:54] Successfully extracted stage using sed: beta3
[2026-06-10 12:16:54] Current stage detected in VERSION.json: beta3
[2026-06-10 12:16:54] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/package.json using sed...
[2026-06-10 12:16:54] Successfully extracted revision using sed: 03
[2026-06-10 12:16:54] Current revision detected in package.json: 03
[2026-06-10 12:16:54] Default revision set to: 00
[2026-06-10 12:16:54] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 12:16:54] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 12:16:54] Attempting to extract current revision from /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/package.json using sed (Note: This is fragile)
[2026-06-10 12:16:54] Successfully extracted revision using sed: 03
[2026-06-10 12:16:54] Current revision: 03.
[2026-06-10 12:16:54] Final revision determined: 03
[2026-06-10 12:16:54] Freeze mode enabled: version values and branch references will be updated.
[2026-06-10 12:16:54] Starting file modifications...
[2026-06-10 12:16:54] Processing /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/VERSION.json
[2026-06-10 12:16:54] Processing /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/package.json
[2026-06-10 12:16:54] Updating CHANGELOG.md...
[2026-06-10 12:16:54] Attempting to extract .version from /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/package.json using sed (Note: This is fragile)
[2026-06-10 12:16:54] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 12:16:54] Replacing default: main with default: v5.0.0 in /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/.github/workflows/manual-build.yml (where applicable)
[2026-06-10 12:16:54] Replacing default: main with default: v5.0.0 in /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/.github/workflows/dev-environment.yml (where applicable)
[2026-06-10 12:16:54] Replacing default: main with default: v5.0.0 in /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/.github/workflows/5_builderpackage_security_plugin.yml (where applicable)
[2026-06-10 12:16:54] Replacing default: main with default: v5.0.0 in /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 12:16:54] File modifications completed.
[2026-06-10 12:16:54] Repository bump completed successfully. Log file: /home/adman23/development/wazuh/src/wazuh-security-dashboards-plugin/tools/repository_bumper_2026-06-10_12-16-54-083.log
```


**Diff:**

```diff
diff --git a/.github/workflows/5_builderpackage_security_plugin.yml b/.github/workflows/5_builderpackage_security_plugin.yml
index 813da00..4f5e837 100644
--- a/.github/workflows/5_builderpackage_security_plugin.yml
+++ b/.github/workflows/5_builderpackage_security_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Source code reference (branch, tag or commit SHA)
-        default: main
+        default: v5.0.0
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Source code reference (branch, tag or commit SHA)
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index b564ae4..a3ab4da 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -20,7 +20,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true
diff --git a/.github/workflows/dev-environment.yml b/.github/workflows/dev-environment.yml
index 4517df1..8816231 100644
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -12,7 +12,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Source code reference (branch, tag or commit SHA).
       command:
         required: true
diff --git a/.github/workflows/manual-build.yml b/.github/workflows/manual-build.yml
index 86cfb0b..b3b91e3 100644
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -12,13 +12,13 @@ on:
         required: true
         type: string
         description: Source code reference (branch, tag or commit SHA)
-        default: main
+        default: v5.0.0
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Source code reference (branch, tag or commit SHA)
 
 jobs:
```

</details>

### Tests

- Test each command on evidence and any other use case of interest.


### Check List
- [x] Commits are signed per the DCO using --signoff.