### PR TITLE
Migrate security plugin package-building workflow runners to AWS Code Build

### DIFF
--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Deploy and run command
-    runs-on: wz-linux-amd64
+    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4

--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   bump:
     name: Repository bumper
-    runs-on: ubuntu-22.04
+    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
### Description

The workflow runners are being updated
 
### Test

https://github.com/wazuh/wazuh-security-dashboards-plugin/actions/runs/27960037314

### Check List
- [ ] All tests pass
  - [ ] `yarn test:jest`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff 
