### PR TITLE
Migrate non-build workflows to GitHub-hosted runner to reduce costs

### DIFF
--- a/.github/workflows/4_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/4_builderprecompiled_base-dev-environment.yml
@@ -63,7 +63,7 @@ jobs:
       pull-requests: write
       id-token: write
     name: Deploy and run command
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Download the plugin's source code
         uses: actions/checkout@v4

--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -63,7 +63,7 @@ jobs:
       pull-requests: write
       id-token: write
     name: Deploy and run command
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Download the plugin's source code
         uses: actions/checkout@v4

--- a/.github/workflows/6_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/6_builderprecompiled_base-dev-environment.yml
@@ -52,7 +52,7 @@ jobs:
   # using a pre-built Docker image, hosted in Quay.io.
   deploy_and_run_command:
     name: Deploy and run command
-    runs-on: codebuild-github-actions-codebuild-runner-dashboard-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Step 01 - Download the plugin's source code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
Migrate the reusable base workflow (`*_builderprecompiled_base-dev-environment.yml`) from the dedicated CodeBuild runner to the default GitHub-hosted runner (`ubuntu-24.04`), reducing unnecessary usage of the paid runner. This is a runner label change only; no build/test logic is modified.

Workflows moved to `ubuntu-24.04`:
- `4/5/6_builderprecompiled_base-dev-environment.yml`

`4/5/6_builderpackage_reporting_plugin.yml` call this workflow as a reusable workflow via `uses:` and inherit the runner change automatically — no changes needed there.

Workflows that remain on the dedicated runner (actual package builds / version bumping):
- `4/5/6_builderpackage_reporting_plugin.yml`
- `4/5/6_bumper_repository.yml`

### Issues Resolved
Related to #4774 (FR3).

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
