### PR TITLE
Fix tag references on bump when --tag is provided

### DIFF
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -87,7 +87,7 @@ jobs:
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
           tag=${{ env.TAG }}
-
+          
           # Both version and stage provided
           if [[ -n "$version" && -n "$stage" && "$tag" != "true" ]]; then
             script_params="--version ${version} --stage ${stage}"
@@ -111,34 +111,34 @@ jobs:
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
-      # - name: Commit and push changes
-      #   run: |
-      #     git add .
-      #     git commit -m "feat: bump ${{ github.ref_name }}"
-      #     git push origin ${{ steps.vars.outputs.branch_name }}
+      - name: Commit and push changes
+        run: |
+          git add .
+          git commit -m "feat: bump ${{ github.ref_name }}"
+          git push origin ${{ steps.vars.outputs.branch_name }}
 
-      # - name: Create pull request
-      #   id: create_pr
-      #   run: |
-      #     gh auth setup-git
-      #     PR_URL=$(gh pr create \
-      #       --title "Bump ${{ github.ref_name }} branch" \
-      #       --body "Issue: ${{ inputs.issue-link }}" \
-      #       --base ${{ github.ref_name }} \
-      #       --head ${{ steps.vars.outputs.branch_name }})
+      - name: Create pull request
+        id: create_pr
+        run: |
+          gh auth setup-git
+          PR_URL=$(gh pr create \
+            --title "Bump ${{ github.ref_name }} branch" \
+            --body "Issue: ${{ inputs.issue-link }}" \
+            --base ${{ github.ref_name }} \
+            --head ${{ steps.vars.outputs.branch_name }})
 
-      #     echo "Pull request created: ${PR_URL}"
-      #     echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
+          echo "Pull request created: ${PR_URL}"
+          echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
-      # - name: Merge pull request
-      #   run: |
-      #     # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-      #     gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+      - name: Merge pull request
+        run: |
+          # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
 
-      # - name: Show logs
-      #   run: |
-      #     echo "Bump complete."
-      #     echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-      #     echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
-      #     echo "Bumper scripts logs:"
-      #     cat ${BUMP_LOG_PATH}/repository_bumper*log
+      - name: Show logs
+        run: |
+          echo "Bump complete."
+          echo "Branch: ${{ steps.vars.outputs.branch_name }}"
+          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          echo "Bumper scripts logs:"
+          cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -81,16 +81,20 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          TAG: ${{ inputs.tag }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
-
+          tag=${{ env.TAG }}
+          
           # Both version and stage provided
-          if [[ -n "$version" && -n "$stage" ]]; then
+          if [[ -n "$version" && -n "$stage" && "$tag" != "true" ]]; then
             script_params="--version ${version} --stage ${stage}"
-          elif [[ -z "$version" && -n "$stage" ]]; then
-            script_params="--stage ${stage}"
+          elif [[ -z "$version" && -n "$stage" && "$tag" == "true" ]]; then
+            script_params="--stage ${stage} --tag"
+          elif [[ -z "$version" && -z "$stage" && "$tag" == "true" ]]; then
+            script_params="--tag"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')

--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -87,7 +87,7 @@ jobs:
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
           tag=${{ env.TAG }}
-          
+
           # Both version and stage provided
           if [[ -n "$version" && -n "$stage" && "$tag" != "true" ]]; then
             script_params="--version ${version} --stage ${stage}"
@@ -111,34 +111,34 @@ jobs:
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
-      - name: Commit and push changes
-        run: |
-          git add .
-          git commit -m "feat: bump ${{ github.ref_name }}"
-          git push origin ${{ steps.vars.outputs.branch_name }}
+      # - name: Commit and push changes
+      #   run: |
+      #     git add .
+      #     git commit -m "feat: bump ${{ github.ref_name }}"
+      #     git push origin ${{ steps.vars.outputs.branch_name }}
 
-      - name: Create pull request
-        id: create_pr
-        run: |
-          gh auth setup-git
-          PR_URL=$(gh pr create \
-            --title "Bump ${{ github.ref_name }} branch" \
-            --body "Issue: ${{ inputs.issue-link }}" \
-            --base ${{ github.ref_name }} \
-            --head ${{ steps.vars.outputs.branch_name }})
+      # - name: Create pull request
+      #   id: create_pr
+      #   run: |
+      #     gh auth setup-git
+      #     PR_URL=$(gh pr create \
+      #       --title "Bump ${{ github.ref_name }} branch" \
+      #       --body "Issue: ${{ inputs.issue-link }}" \
+      #       --base ${{ github.ref_name }} \
+      #       --head ${{ steps.vars.outputs.branch_name }})
 
-          echo "Pull request created: ${PR_URL}"
-          echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
+      #     echo "Pull request created: ${PR_URL}"
+      #     echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
-      - name: Merge pull request
-        run: |
-          # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+      # - name: Merge pull request
+      #   run: |
+      #     # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
+      #     gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
 
-      - name: Show logs
-        run: |
-          echo "Bump complete."
-          echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
-          echo "Bumper scripts logs:"
-          cat ${BUMP_LOG_PATH}/repository_bumper*log
+      # - name: Show logs
+      #   run: |
+      #     echo "Bump complete."
+      #     echo "Branch: ${{ steps.vars.outputs.branch_name }}"
+      #     echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+      #     echo "Bumper scripts logs:"
+      #     cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -307,6 +307,9 @@ main() {
 
   # Perform pre-update checks
   pre_update_checks
+  if [ -z "$VERSION" ]; then
+    VERSION=$CURRENT_VERSION # If no version provided, use current version
+  fi
 
   # Compare versions and determine revision
   compare_versions_and_set_revision

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -13,6 +13,7 @@ LOG_FILE="${SCRIPT_PATH}/repository_bumper_${DATE_TIME}.log"
 VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
+TAG=false
 CURRENT_VERSION=""
 
 # --- Helper Functions ---
@@ -26,11 +27,12 @@ log() {
 
 # Function to show usage
 usage() {
-  echo "Usage: $0 --version VERSION --stage STAGE [--help]"
+  echo "Usage: $0 --version VERSION --stage STAGE [--tag] [--help]"
   echo ""
   echo "Parameters:"
   echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
   echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
+  echo "  --tag               Create a tag for the specified version and stage"
   echo "  --help              Display this help message"
   echo ""
   echo "Example:"
@@ -52,6 +54,10 @@ parse_arguments() {
       STAGE="$2"
       shift 2
       ;;
+    --tag)
+      TAG=true
+      shift
+      ;;
     --help)
       usage
       exit 0
@@ -67,21 +73,21 @@ parse_arguments() {
 
 # Function to validate input parameters
 validate_input() {
-  if [ -z "$VERSION" ]; then
-    log "ERROR: Version parameter is required"
+  if [ -z "$VERSION" ] && [ "$TAG" != true ]; then
+    log "ERROR: --version is required unless --tag is set"
     usage
     exit 1
   fi
-  if [ -z "$STAGE" ]; then
-    log "ERROR: Stage parameter is required"
+  if [ -z "$STAGE" ] && [ "$TAG" != true ]; then
+    log "ERROR: --stage is required unless --tag is set"
     usage
     exit 1
   fi
-  if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [ -n "$VERSION" ] && ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     log "ERROR: Version must be in the format x.y.z (e.g., 4.6.0)"
     exit 1
   fi
-  if ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
+  if [ -n "$STAGE" ] && ! [[ $STAGE =~ ^[a-zA-Z]+[0-9]+$ ]]; then
     log "ERROR: Stage must be alphanumeric (e.g., alpha0, beta1, rc2)"
     exit 1
   fi
@@ -278,39 +284,6 @@ update_package_json() {
   fi
 }
 
-update_manual_build_workflow() {
-  local WORKFLOW_FILE="${REPO_PATH}/.github/workflows/manual-build.yml"
-  if [ -f "$WORKFLOW_FILE" ]; then
-    log "Processing $WORKFLOW_FILE"
-    local modified=false
-    # Update version in manual build workflow
-    # on:
-    #   workflow_call:
-    #     inputs:
-    #       reference:
-    #         required: true
-    #         type: string
-    #         description: Source code reference (branch, tag or commit SHA)
-    #         default: 4.14.0
-    # Update the default value for the reference input
-    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
-      log "Attempting to update default reference to $VERSION in $WORKFLOW_FILE"
-      # Note: This sed command assumes a specific formatting and might be fragile.
-      # It looks for the line starting with "default:" and replaces the version value
-      # Ensure to escape special characters if necessary
-      sed -i "s/^\(\s*default:\s*\)$CURRENT_VERSION/\1$VERSION/" "$WORKFLOW_FILE"
-      modified=true
-    fi
-
-    if [[ $modified == true ]]; then
-      log "Successfully updated $WORKFLOW_FILE with new default reference: $VERSION"
-    fi
-  else
-    log "WARNING: $WORKFLOW_FILE not found. Skipping update."
-  fi
-  log "Updating manual build workflow..."
-
-}
 
 # --- Main Execution ---
 main() {
@@ -343,7 +316,6 @@ main() {
 
   update_root_version_json
   update_package_json
-  update_manual_build_workflow
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"


### PR DESCRIPTION
### Description

This pull request fixes the git references in some files on bump when --tag is provided.

Side changes:
- Add the `--tag` flag to the bumper script

### Issues Resolved

- https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/672

### Testing

Modify the workflow so that it doesn't create a PR or merge anything, just to test that the script runs correctly; that change has already been reverted.

- https://github.com/wazuh/wazuh-security-dashboards-plugin/actions/runs/28966901160/job/85952285520


- Run `./tools/repository_bumper.sh --tag --stage rc1`

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).