### PR TITLE
Change the changelog format to use a table per block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Added
 
-- Support for Wazuh 5.0.0
+| Issue | Comment                 |
+| ----- | ----------------------- |
+|       | Support for Wazuh 5.0.0 |
 
 ## Prior versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Added
 
-| Issue | Comment |
-| ----- | ------- |
+| Issue                                                                      | Comment                 |
+| -------------------------------------------------------------------------- | ----------------------- |
 | [#37](https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/37) | Support for Wazuh 5.0.0 |
 
 ## Prior versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Added
 
-| Issue | Comment                 |
-| ----- | ----------------------- |
-|       | Support for Wazuh 5.0.0 |
+| Issue | Comment |
+| ----- | ------- |
+
 
 ## Prior versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 | Issue | Comment |
 | ----- | ------- |
-
+| [#37](https://github.com/wazuh/wazuh-security-dashboards-plugin/issues/37) | Support for Wazuh 5.0.0 |
 
 ## Prior versions
 

--- a/tools/changelog_bump.sh
+++ b/tools/changelog_bump.sh
@@ -8,9 +8,9 @@
 # From 5.x, each changelog only contains its own version changes and
 # references the prior changelogs with links, so on a version bump this
 # script:
-#   - Resets the changelog to a single "## [vX.Y.Z]" entry with empty
-#     Added/Changed/Removed/Fixed sections, where Added starts with the
-#     "- Support for Wazuh X.Y.Z" entry.
+#   - Resets the changelog to a single "## [vX.Y.Z]" entry with an empty
+#     "| Issue | Comment |" table under each of the Added/Changed/
+#     Removed/Fixed sections.
 #   - Rebuilds the "## Prior versions" section with the two most recent
 #     minors below the new version, including every patch of each,
 #     newest first.
@@ -112,7 +112,18 @@ function print_prior_versions_section() {
 }
 
 # ====
-# Rewrite CHANGELOG.md with the new version entry (empty sections) and the
+# Print a changelog section heading followed by an empty entries table.
+# Arguments:
+#   $1 - section name (Added, Changed, Removed, Fixed)
+# ====
+function print_section() {
+    printf '### %s\n\n' "$1"
+    printf '| Issue | Comment |\n'
+    printf '| ----- | ------- |\n\n'
+}
+
+# ====
+# Rewrite CHANGELOG.md with the new version entry (empty tables) and the
 # rebuilt "## Prior versions" section.
 # Arguments:
 #   $1 - new version
@@ -124,11 +135,10 @@ function write_changelog() {
 
     {
         printf '## [v%s]\n\n' "$new_version"
-        printf '### Added\n\n'
-        printf -- '- Support for Wazuh %s\n\n' "$new_version"
-        printf '### Changed\n\n'
-        printf '### Removed\n\n'
-        printf '### Fixed\n\n'
+        print_section 'Added'
+        print_section 'Changed'
+        print_section 'Removed'
+        print_section 'Fixed'
         print_prior_versions_section "$new_version"
     } > "$temp_file"
 

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -51,8 +51,8 @@ there for debugging (the directory is git-ignored).
 
 - Argument validation (`--help`, missing/extra args, malformed `x.y.z`
   versions) and that failures leave `CHANGELOG.md` untouched.
-- Version bump: changelog reset to the new `## [vX.Y.Z]` entry with empty
-  sections and the `- Support for Wazuh X.Y.Z` line; "Prior versions" rebuilt
+- Version bump: changelog reset to the new `## [vX.Y.Z]` entry with an empty
+  `| Issue | Comment |` table per section; "Prior versions" rebuilt
   with the two most recent minors below the new version, every patch of each,
   newest first; non-version tags filtered out; `v`-prefixed tags normalized.
 - Stage-only bump (same version) and `--tag`: entries preserved, only the

--- a/tools/tests/test_changelog_bump.sh
+++ b/tools/tests/test_changelog_bump.sh
@@ -37,11 +37,12 @@ run_tool changelog_bump.sh 5.1.0 5.0.0
 assert_eq 0 "$STATUS" "exits 0"
 CONTENT=$(cat "$WORK/CHANGELOG.md")
 assert_contains "$CONTENT" "## [v5.1.0]" "new version heading"
-assert_contains "$CONTENT" "- Support for Wazuh 5.1.0" "Support for Wazuh entry"
 assert_contains "$CONTENT" "### Added" "Added section"
 assert_contains "$CONTENT" "### Changed" "Changed section"
 assert_contains "$CONTENT" "### Removed" "Removed section"
 assert_contains "$CONTENT" "### Fixed" "Fixed section"
+assert_eq 4 "$(grep -c '^| Issue | Comment |$' "$WORK/CHANGELOG.md")" \
+  "one empty entries table per section"
 assert_not_contains "$CONTENT" "Some existing feature entry" "old entries removed"
 assert_eq "$(expected_priors 5.0.0 4.10.2 4.10.1 4.10.0)" "$(prior_versions_block)" \
   "Prior versions = last 2 minors (every patch, newest first)"
@@ -78,12 +79,14 @@ cat >"$WORK/CHANGELOG.md" <<'EOF'
 
 ### Added
 
-- Support for Wazuh 5.0.0
+| Issue | Comment |
+| ----- | ------- |
+| [#1](https://github.com/wazuh/test-repo/issues/1) | Some existing feature entry |
 EOF
 run_tool changelog_bump.sh 5.0.0 5.0.0
 assert_eq 0 "$STATUS" "exits 0"
 CONTENT=$(cat "$WORK/CHANGELOG.md")
-assert_contains "$CONTENT" "- Support for Wazuh 5.0.0" "entries preserved"
+assert_contains "$CONTENT" "| Some existing feature entry |" "entries preserved"
 assert_contains "$CONTENT" "## Prior versions" "section appended"
 assert_eq "$(expected_priors 4.10.2 4.10.1 4.10.0 4.9.1 4.9.0)" "$(prior_versions_block)" \
   "list built correctly"

--- a/tools/tests/test_helpers.sh
+++ b/tools/tests/test_helpers.sh
@@ -153,14 +153,24 @@ EOF
 
 ### Added
 
-- Support for Wazuh 5.0.0
-- Some existing feature entry
+| Issue | Comment |
+| ----- | ------- |
+| [#1](https://github.com/wazuh/test-repo/issues/1) | Some existing feature entry |
 
 ### Changed
 
+| Issue | Comment |
+| ----- | ------- |
+
 ### Removed
 
+| Issue | Comment |
+| ----- | ------- |
+
 ### Fixed
+
+| Issue | Comment |
+| ----- | ------- |
 
 ## Prior versions
 


### PR DESCRIPTION
## Description

The 5.x changelog standard renders each `Added`/`Changed`/`Fixed`/`Removed` block as a
bullet list where every entry ends with its issue or pull request references. The agreed
format is now a table per block, with the references in the first column and the entry
description in the second one, so references stay aligned and are easier to scan on
GitHub.

This pull request applies that format to this repository's `CHANGELOG.md`. It is a
format-only change: no entry was added, removed, reworded or relinked.

Related to wazuh/wazuh-dashboard#1476

## Proposed Changes

- Converted every `Added`/`Changed`/`Fixed`/`Removed` block in `CHANGELOG.md` into a
  `| Issue | Comment |` table.
- Moved each entry's existing references verbatim into the `Issue` column; entries with
  several references keep all of them in that column.
- Kept each entry's description unchanged in the `Comment` column.
- Left the section heading levels and the `Prior versions` list untouched.

No new links were created and no existing link was rewritten: entries that already
pointed to an issue keep the issue link, entries that pointed to a pull request keep the
pull request link, and entries that had no reference keep an empty `Issue` cell.

### Results and Evidence

<!-- Add a screenshot of the rendered CHANGELOG.md as seen in the GitHub "Files changed" / preview tab. -->

Verification performed:

- The number of table rows matches the number of previous bullet entries.
- A round-trip check (description + references vs. the original line) matches for every
  entry, so no text was lost or altered.
- `git diff` contains only removed bullet lines and added table lines; no other content
  in the file changed.
- Prettier formatting check passes for the file.

### Artifacts Affected

- `CHANGELOG.md`

### Configuration Changes

None.

### Documentation Updates

None. The changelog format is documented in wazuh/wazuh-dashboard#1476.

### Tests Introduced

None. Documentation-only change with no runtime impact.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [x] Tests cover the new functionality <!-- N/A: documentation-only change -->
- [x] Configuration changes documented <!-- N/A: no configuration changes -->
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (`no changelog`)
