### PR TITLE
Report skipped bumps in the repository bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -177,11 +177,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
+          echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -224,6 +227,17 @@ jobs:
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
+
+      - name: "Result: original bump pull request not found"
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: "Result: no changes to commit"
+        if: >-
+          (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Show logs
         if: inputs.revert != true

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -228,11 +228,11 @@ jobs:
         run: |
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
-      - name: "Result: original bump pull request not found"
+      - name: 'Result: original bump pull request not found'
         if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
         run: echo "There is no original bump pull request to revert, nothing to do."
 
-      - name: "Result: no changes to commit"
+      - name: 'Result: no changes to commit'
         if: >-
           (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
           (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&


### PR DESCRIPTION
## Description

Closes #705

The release orchestration in `wazuh-qa-automation` now distinguishes a repository bump that **failed** from one that **had nothing to do** (see [wazuh-qa-automation#8027](https://github.com/wazuh/wazuh-qa-automation/issues/8027)). Today `.github/workflows/5_bumper_repository.yml` ends with the `failure` conclusion in two harmless situations, so the orchestrator has no way to tell them apart from a real failure:

- On a revert run (`revert: true`), when the original bump pull request does not exist because that bump introduced no changes, the `Revert references (Revert)` step ran `exit 1`.
- On a bump run, when the bump script produces no changes, the run had no way to report that fact by step name (the existing `Check for changes` step already prevents the `git commit` failure, but nothing surfaced the outcome to the orchestrator).

## Proposed Changes

In `.github/workflows/5_bumper_repository.yml`:

- `Revert references (Revert)`: when the original bump PR is not found, the step now sets `pr_found=false` and `has_changes=false` outputs and exits `0` instead of `exit 1`. When the PR is found, it now also sets `pr_found=true`.
- Added two new report-only steps, kept at the exact names the orchestrator matches on (case-insensitive, trimmed):
  - `"Result: original bump pull request not found"` — runs when a revert finds no original bump PR.
  - `"Result: no changes to commit"` — runs when a bump produced no changes, or a revert found the original PR but nothing left to revert.
- `Push changes`, `Create pull request` and `Merge pull request` were already conditioned on `check_changes`/`revert_step` outputs, so they continue to be skipped in both no-op cases without further changes.

No changes to `public/`, `server/`, or `common/` — this is a CI workflow-only change.

### Results and Evidence

<!-- Attach the links of the four validation runs required by the issue (revert-with-no-PR, bump-with-no-changes, normal bump, normal revert) once executed on the release branch, per the issue's "Validations" section. -->

### Artifacts Affected

None (CI workflow only).

### Configuration Changes

None — no new workflow inputs; behavior of the two `Revert references (Revert)` outputs (`pr_found`, `has_changes`) is additive.

### Documentation Updates

None.

### Tests Introduced

None (GitHub Actions workflow; validated by running the four scenarios from the issue's "Validations" section directly on the release branch — see Results and Evidence).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
