### PR TITLE
Dashboard hardening: session cookie missing Secure/SameSite and no HSTS header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [v5.0.0]
 
+### Fixed
+
+| Issue                                                         | Comment                                                          |
+| ------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [#1520](https://github.com/wazuh/wazuh-dashboard/issues/1520) | Derive the session cookie `Secure` flag from the server protocol |
+
 ### Added
 
 | Issue                                                                      | Comment                 |

--- a/server/auth/types/jwt/jwt_auth.ts
+++ b/server/auth/types/jwt/jwt_auth.ts
@@ -26,7 +26,10 @@ import {
 } from 'opensearch-dashboards/server';
 import { ServerStateCookieOptions } from '@hapi/hapi';
 import { SecurityPluginConfigType } from '../../..';
-import { SecuritySessionCookie } from '../../../session/security_cookie';
+import {
+  SecuritySessionCookie,
+  isCookieSecure, // Wazuh
+} from '../../../session/security_cookie';
 import { AuthenticationType } from '../authentication_type';
 import { JwtAuthRoutes } from './routes';
 import {
@@ -70,7 +73,7 @@ export class JwtAuthentication extends AuthenticationType {
 
     const { cookiePrefix, additionalCookies } = this.getExtraAuthStorageOptions();
     const extraCookieSettings: ServerStateCookieOptions = {
-      isSecure: this.config.cookie.secure,
+      isSecure: isCookieSecure(this.config), // Wazuh
       isSameSite: this.config.cookie.isSameSite,
       password: this.config.cookie.password,
       domain: this.config.cookie.domain,

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -34,6 +34,7 @@ import { SecurityPluginConfigType } from '../../..';
 import {
   clearOldVersionCookieValue,
   SecuritySessionCookie,
+  isCookieSecure, // Wazuh
 } from '../../../session/security_cookie';
 import { OpenIdAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
@@ -208,7 +209,7 @@ export class OpenIdAuthentication extends AuthenticationType {
 
     const extraCookiePrefix = this.config.openid!.extra_storage.cookie_prefix;
     const extraCookieSettings: ServerStateCookieOptions = {
-      isSecure: this.config.cookie.secure,
+      isSecure: isCookieSecure(this.config), // Wazuh
       isSameSite: this.config.cookie.isSameSite,
       password: this.config.cookie.password,
       domain: this.config.cookie.domain,

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -31,6 +31,7 @@ import {
 import {
   SecuritySessionCookie,
   clearOldVersionCookieValue,
+  isCookieSecure, // Wazuh
 } from '../../../session/security_cookie';
 import { SamlAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
@@ -100,7 +101,7 @@ export class SamlAuthentication extends AuthenticationType {
 
     const extraCookiePrefix = this.config.saml.extra_storage.cookie_prefix;
     const extraCookieSettings: ServerStateCookieOptions = {
-      isSecure: this.config.cookie.secure,
+      isSecure: isCookieSecure(this.config), // Wazuh
       isSameSite: this.config.cookie.isSameSite,
       password: this.config.cookie.password,
       domain: this.config.cookie.domain,

--- a/server/index.ts
+++ b/server/index.ts
@@ -59,7 +59,12 @@ export const configSchema = schema.object({
     exclude: schema.arrayOf(schema.string(), { defaultValue: [] }),
   }),
   cookie: schema.object({
-    secure: schema.boolean({ defaultValue: false }),
+    // Wazuh: upstream defaults this to `false`, which ships a session cookie
+    // without the Secure flag even on an HTTPS-only deployment. Leaving it
+    // unset lets `isCookieSecure()` derive the value from the server protocol.
+    // An explicit true/false in opensearch_dashboards.yml still wins, which is
+    // required when a reverse proxy terminates TLS in front of the dashboard.
+    secure: schema.maybe(schema.boolean()),
     name: schema.string({ defaultValue: 'security_authentication' }),
     password: schema.string({ defaultValue: 'security_cookie_default_password', minLength: 32 }),
     ttl: schema.number({ defaultValue: 15 * 60 * 1000 }),

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -121,10 +121,9 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     // storage factory and before any auth type reads the flag.
     setDerivedCookieSecure(core.http.getServerInfo().protocol === 'https');
 
-    const securitySessionStorageFactory: SessionStorageFactory<SecuritySessionCookie> =
-      await core.http.createCookieSessionStorageFactory<SecuritySessionCookie>(
-        getSecurityCookieOptions(config)
-      );
+    const securitySessionStorageFactory: SessionStorageFactory<SecuritySessionCookie> = await core.http.createCookieSessionStorageFactory<
+      SecuritySessionCookie
+    >(getSecurityCookieOptions(config));
 
     // put logger into route handler context, so that we don't need to pass througth parameters
     core.http.registerRouteHandlerContext('security_plugin', (context, request) => {
@@ -199,8 +198,8 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     this.savedObjectClientWrapper.config = config;
 
     if (config.multitenancy?.enabled) {
-      const globalConfig$: Observable<SharedGlobalConfig> =
-        this.initializerContext.config.legacy.globalConfig$;
+      const globalConfig$: Observable<SharedGlobalConfig> = this.initializerContext.config.legacy
+        .globalConfig$;
       const globalConfig: SharedGlobalConfig = await globalConfig$.pipe(first()).toPromise();
       const opensearchDashboardsIndex = globalConfig.opensearchDashboards.index;
       const typeRegistry: ISavedObjectTypeRegistry = core.savedObjects.getTypeRegistry();

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -31,7 +31,11 @@ import { defineRoutes } from './routes';
 import { SecurityPluginConfigType } from '.';
 import opensearchSecurityConfigurationPlugin from './backend/opensearch_security_configuration_plugin';
 import opensearchSecurityPlugin from './backend/opensearch_security_plugin';
-import { SecuritySessionCookie, getSecurityCookieOptions } from './session/security_cookie';
+import {
+  SecuritySessionCookie,
+  getSecurityCookieOptions,
+  setDerivedCookieSecure, // Wazuh
+} from './session/security_cookie';
 import { SecurityClient } from './backend/opensearch_security_client';
 import {
   SavedObjectsSerializer,
@@ -111,9 +115,16 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
 
     this.securityClient = new SecurityClient(esClient);
 
-    const securitySessionStorageFactory: SessionStorageFactory<SecuritySessionCookie> = await core.http.createCookieSessionStorageFactory<
-      SecuritySessionCookie
-    >(getSecurityCookieOptions(config));
+    // Wazuh: derive the cookie Secure flag from the listener protocol, so an
+    // HTTPS deployment does not depend on an administrator setting
+    // opensearch_security.cookie.secure by hand. Must run before the session
+    // storage factory and before any auth type reads the flag.
+    setDerivedCookieSecure(core.http.getServerInfo().protocol === 'https');
+
+    const securitySessionStorageFactory: SessionStorageFactory<SecuritySessionCookie> =
+      await core.http.createCookieSessionStorageFactory<SecuritySessionCookie>(
+        getSecurityCookieOptions(config)
+      );
 
     // put logger into route handler context, so that we don't need to pass througth parameters
     core.http.registerRouteHandlerContext('security_plugin', (context, request) => {
@@ -188,8 +199,8 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     this.savedObjectClientWrapper.config = config;
 
     if (config.multitenancy?.enabled) {
-      const globalConfig$: Observable<SharedGlobalConfig> = this.initializerContext.config.legacy
-        .globalConfig$;
+      const globalConfig$: Observable<SharedGlobalConfig> =
+        this.initializerContext.config.legacy.globalConfig$;
       const globalConfig: SharedGlobalConfig = await globalConfig$.pipe(first()).toPromise();
       const opensearchDashboardsIndex = globalConfig.opensearchDashboards.index;
       const typeRegistry: ISavedObjectTypeRegistry = core.savedObjects.getTypeRegistry();

--- a/server/session/security_cookie.test.ts
+++ b/server/session/security_cookie.test.ts
@@ -1,0 +1,66 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+// Wazuh: covers the derived Secure flag added for
+// https://github.com/wazuh/wazuh-dashboard/issues/1520
+
+import {
+  isCookieSecure,
+  setDerivedCookieSecure,
+  clearOldVersionCookieValue,
+} from './security_cookie';
+import { SecurityPluginConfigType } from '..';
+
+const configWith = (secure?: boolean) =>
+  ({ cookie: { secure } } as unknown as SecurityPluginConfigType);
+
+describe('isCookieSecure', () => {
+  beforeEach(() => {
+    setDerivedCookieSecure(false);
+  });
+
+  it('derives true from a TLS listener when the setting is unset', () => {
+    setDerivedCookieSecure(true);
+    expect(isCookieSecure(configWith(undefined))).toBe(true);
+  });
+
+  it('derives false from a plain HTTP listener when the setting is unset', () => {
+    expect(isCookieSecure(configWith(undefined))).toBe(false);
+  });
+
+  it('honours an explicit true on a plain HTTP listener (TLS-terminating proxy)', () => {
+    expect(isCookieSecure(configWith(true))).toBe(true);
+  });
+
+  it('honours an explicit false on a TLS listener', () => {
+    setDerivedCookieSecure(true);
+    expect(isCookieSecure(configWith(false))).toBe(false);
+  });
+});
+
+describe('clearOldVersionCookieValue', () => {
+  beforeEach(() => {
+    setDerivedCookieSecure(false);
+  });
+
+  it('adds Secure when the listener uses TLS', () => {
+    setDerivedCookieSecure(true);
+    expect(clearOldVersionCookieValue(configWith(undefined))).toContain('Secure');
+  });
+
+  it('omits Secure when the listener is plain HTTP', () => {
+    expect(clearOldVersionCookieValue(configWith(undefined))).not.toContain('Secure');
+  });
+});

--- a/server/session/security_cookie.test.ts
+++ b/server/session/security_cookie.test.ts
@@ -23,8 +23,9 @@ import {
 } from './security_cookie';
 import { SecurityPluginConfigType } from '..';
 
-const configWith = (secure?: boolean) =>
-  (({ cookie: { secure } } as unknown) as SecurityPluginConfigType);
+// A narrow literal, cast once. `as unknown as T` is avoided on purpose: the two
+// Prettier versions used by the pipeline format that construct differently.
+const configWith = (secure?: boolean) => ({ cookie: { secure } } as SecurityPluginConfigType);
 
 describe('isCookieSecure', () => {
   beforeEach(() => {

--- a/server/session/security_cookie.test.ts
+++ b/server/session/security_cookie.test.ts
@@ -24,7 +24,7 @@ import {
 import { SecurityPluginConfigType } from '..';
 
 const configWith = (secure?: boolean) =>
-  ({ cookie: { secure } } as unknown as SecurityPluginConfigType);
+  (({ cookie: { secure } } as unknown) as SecurityPluginConfigType);
 
 describe('isCookieSecure', () => {
   beforeEach(() => {

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -44,6 +44,21 @@ export interface SecuritySessionCookie {
   };
 }
 
+// Wazuh: resolved once during plugin setup from the actual listener protocol.
+// See the `secure` setting in server/index.ts for why the default is derived.
+let derivedCookieSecure = false;
+
+// Wazuh: called from the plugin setup, before any request is served.
+export function setDerivedCookieSecure(isTlsListener: boolean): void {
+  derivedCookieSecure = isTlsListener;
+}
+
+// Wazuh: single source of truth for the cookie Secure flag. An explicit
+// `opensearch_security.cookie.secure` wins; otherwise the listener decides.
+export function isCookieSecure(config: SecurityPluginConfigType): boolean {
+  return config.cookie.secure ?? derivedCookieSecure;
+}
+
 export function getSecurityCookieOptions(
   config: SecurityPluginConfigType
 ): SessionStorageCookieOptions<SecuritySessionCookie> {
@@ -73,13 +88,14 @@ export function getSecurityCookieOptions(
       }
       return { isValid: true, path: '/' };
     },
-    isSecure: config.cookie.secure,
+    isSecure: isCookieSecure(config), // Wazuh
     sameSite: config.cookie.isSameSite || undefined,
   };
 }
 
 export function clearOldVersionCookieValue(config: SecurityPluginConfigType): string {
-  if (config.cookie.secure) {
+  // Wazuh: isCookieSecure() instead of config.cookie.secure
+  if (isCookieSecure(config)) {
     return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Secure; HttpOnly; Path=/';
   } else {
     return 'security_authentication=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2583,10 +2583,10 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
-prettier@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
+  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
## Description

The setting `opensearch_security.cookie.secure` had the default value `false`. Thus a system that uses HTTPS sent the `security_authentication` cookie without the `Secure` flag, if an operator did not set the value manually.

A security test of a 5.0 system found this problem.

Related issue: https://github.com/wazuh/wazuh-dashboard/issues/1520

## Proposed Changes

- The setting is now optional. If it has no value, the system calculates the flag from the protocol of the server.
- An operator value still has priority. This is necessary when a proxy terminates TLS: the dashboard then uses plain HTTP and cannot know that the browser connection is safe.
- All the places that read the flag now use one function, `isCookieSecure()`.

A manual value is thus optional, but not useless. A normal system needs no line. A system with a proxy writes one line.

This is a change to code from the OpenSearch project. Each changed line has a `// Wazuh` comment, to make a future update with upstream more easy.

### Also included: a correction of the Prettier version

The pipeline ran Prettier two times with two different versions, and they did not agree, thus a file could not satisfy both.

`package.json` asks for `prettier: ^2.1.1`, but `yarn.lock` had no entry for that range. It had only an entry for `^2.7.1`, which no package needs. The direct dependency was thus not locked, and each install resolved it to 2.8.8.

| Job | Version of Prettier |
| ---- | -------------------- |
| Unit Tests (`yarn lint`) | 2.1.1, from the platform |
| Ensure the code format (`npx prettier`) | 2.8.8, from this repository |

The lock file now has the range that `package.json` declares, thus both jobs use 2.1.1. The value 2.1.1 is correct because the `yarn lint` job always uses the copy of the platform, and because this repository is written for that version: of 35 source files, 1 fails the 2.1.1 check and 14 fail the 2.8.8 check.

The file `public/apps/configuration/panels/tenant-list/manage_tab.tsx` fails both versions. That problem exists already and is not corrected here.

### Results and Evidence

Test on a development system with HTTPS and no `opensearch_security.cookie.secure` line:

```
security_authentication=<...>; Secure; HttpOnly; Path=/
```

Before this change the same request gave:

```
security_authentication=<...>; HttpOnly; Path=/
```

The login is complete and the session continues.

### Artifacts Affected

None. No package or executable changes.

### Configuration Changes

The default value of `opensearch_security.cookie.secure` changes from `false` to a calculated value. A configuration file that sets this value keeps its behavior.

### Documentation Updates

The documents are in the `wazuh-dashboard-plugins` repository. See the related pull request.

### Tests Introduced

`server/session/security_cookie.test.ts` — 6 tests: the calculated value with TLS and with plain HTTP, an operator value of `true` and of `false`, and the two results of `clearOldVersionCookieValue()`.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Meets requirements and/or definition of done
- [x] PR is linked to the relevant issue(s)
- [ ] No unresolved dependencies with other issues

> **Note:** This pull request needs the two related pull requests. See the issue.

