### PR TITLE
l10n: wrap login/account UI and add Russian (ru-RU) catalogs

### DIFF
--- a/.i18nrc.json
+++ b/.i18nrc.json
@@ -1,0 +1,7 @@
+{
+  "prefix": "security",
+  "paths": {
+    "security": "."
+  },
+  "translations": ["translations/en-US.json", "translations/ru-RU.json"]
+}

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -26,6 +26,7 @@ import {
   EuiPopover,
   EuiText,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { CoreStart } from 'opensearch-dashboards/public';
 import React, { useCallback } from 'react';
 import { RoleInfoPanel } from './role-info-panel';
@@ -129,13 +130,17 @@ export function AccountNavButton(props: {
         size="xs"
         onClick={() => setModal(<RoleInfoPanel {...props} handleClose={() => setModal(null)} />)}
       >
-        View roles and identities
+        {i18n.translate('security.account.viewRolesAndIdentities', {
+          defaultMessage: 'View roles and identities',
+        })}
       </EuiButtonEmpty>
       {isMultiTenancyEnabled && props.config.multitenancy.enabled && (
         <>
           {horizontalRule}
           <EuiButtonEmpty data-test-subj="switch-tenants" size="xs" onClick={showTenantSwitchPanel}>
-            Switch tenants
+            {i18n.translate('security.account.switchTenants', {
+              defaultMessage: 'Switch tenants',
+            })}
           </EuiButtonEmpty>
         </>
       )}
@@ -156,7 +161,9 @@ export function AccountNavButton(props: {
               )
             }
           >
-            Reset password
+            {i18n.translate('security.account.resetPassword', {
+              defaultMessage: 'Reset password',
+            })}
           </EuiButtonEmpty>
         </>
       )}

--- a/public/apps/account/log-out-button.tsx
+++ b/public/apps/account/log-out-button.tsx
@@ -15,10 +15,15 @@
 
 import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { HttpStart } from 'opensearch-dashboards/public';
 import { externalLogout, logout } from './utils';
 import { AuthType, OPENID_AUTH_LOGOUT, SAML_AUTH_LOGOUT } from '../../../common';
 import { setShouldShowTenantPopup } from '../../utils/storage-utils';
+
+const logOutLabel = i18n.translate('security.account.logOut', {
+  defaultMessage: 'Log out',
+});
 
 export function LogoutButton(props: {
   authType: string;
@@ -36,7 +41,7 @@ export function LogoutButton(props: {
           size="xs"
           onClick={() => externalLogout(props.http, OPENID_AUTH_LOGOUT)}
         >
-          Log out
+          {logOutLabel}
         </EuiButtonEmpty>
       </div>
     );
@@ -50,7 +55,7 @@ export function LogoutButton(props: {
           size="xs"
           onClick={() => externalLogout(props.http, SAML_AUTH_LOGOUT)}
         >
-          Log out
+          {logOutLabel}
         </EuiButtonEmpty>
       </div>
     );
@@ -67,7 +72,7 @@ export function LogoutButton(props: {
           size="xs"
           onClick={() => logout(props.http, props.logoutUrl)}
         >
-          Log out
+          {logOutLabel}
         </EuiButtonEmpty>
       </div>
     );

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -29,6 +29,8 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { FormRow } from '../configuration/utils/form-row';
 import { logout, updateNewPassword } from './utils';
@@ -88,7 +90,12 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
       await validateCurrentPassword(http, props.username, currentPassword);
     } catch (e) {
       setIsCurrentPasswordInvalid(true);
-      setCurrentPasswordError([`Invalid current password. ${e.message}`]);
+      setCurrentPasswordError([
+        i18n.translate('security.account.reset.invalidCurrentPassword', {
+          defaultMessage: 'Invalid current password. {detail}',
+          values: { detail: e.message },
+        }),
+      ]);
       return;
     }
 
@@ -98,7 +105,14 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
 
       await logout(http, props.logoutUrl);
     } catch (e) {
-      setErrorCallOut(constructErrorMessageAndLog(e, 'Failed to reset password.'));
+      setErrorCallOut(
+        constructErrorMessageAndLog(
+          e,
+          i18n.translate('security.account.reset.failed', {
+            defaultMessage: 'Failed to reset password.',
+          })
+        )
+      );
     }
   };
 
@@ -109,14 +123,24 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
         <EuiSpacer />
         <EuiModalBody>
           <EuiText size="s">
-            <h2>Reset password for &quot;{props.username}&quot;</h2>
+            <h2>
+              <FormattedMessage
+                id="security.account.reset.title"
+                defaultMessage='Reset password for "{username}"'
+                values={{ username: props.username }}
+              />
+            </h2>
           </EuiText>
 
           <EuiSpacer />
 
           <FormRow
-            headerText="Current password"
-            helpText="Verify your account by entering your current password."
+            headerText={i18n.translate('security.account.reset.currentPassword', {
+              defaultMessage: 'Current password',
+            })}
+            helpText={i18n.translate('security.account.reset.currentPasswordHelp', {
+              defaultMessage: 'Verify your account by entering your current password.',
+            })}
             isInvalid={isCurrentPasswordInvalid}
             error={currentPasswordError}
           >
@@ -135,7 +159,9 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
           <EuiFlexGroup direction="row">
             <EuiFlexItem grow={false}>
               <FormRow
-                headerText="New password"
+                headerText={i18n.translate('security.account.reset.newPassword', {
+                  defaultMessage: 'New password',
+                })}
                 helpText={passwordHelpText}
                 isInvalid={isNewPasswordInvalid}
               >
@@ -157,8 +183,12 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
           </EuiFlexGroup>
 
           <FormRow
-            headerText="Re-enter new password"
-            helpText="The password must be identical to what you entered above."
+            headerText={i18n.translate('security.account.reset.reenterPassword', {
+              defaultMessage: 'Re-enter new password',
+            })}
+            helpText={i18n.translate('security.account.reset.reenterPasswordHelp', {
+              defaultMessage: 'The password must be identical to what you entered above.',
+            })}
           >
             <EuiCompressedFieldPassword
               data-test-subj="reenter-new-password"
@@ -182,7 +212,9 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
         </EuiModalBody>
         <EuiModalFooter>
           <EuiSmallButtonEmpty data-test-subj="cancel" onClick={props.handleClose}>
-            Cancel
+            {i18n.translate('security.account.reset.cancel', {
+              defaultMessage: 'Cancel',
+            })}
           </EuiSmallButtonEmpty>
 
           <EuiSmallButton
@@ -195,7 +227,9 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
             )}
             onClick={handleReset}
           >
-            Reset
+            {i18n.translate('security.account.reset.submit', {
+              defaultMessage: 'Reset',
+            })}
           </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>

--- a/public/apps/account/role-info-panel.tsx
+++ b/public/apps/account/role-info-panel.tsx
@@ -21,6 +21,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import React, { useCallback } from 'react';
+import { i18n } from '@osd/i18n';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { fetchAccountInfo } from './utils';
 
@@ -48,10 +49,17 @@ export function RoleInfoPanel(props: { coreStart: CoreStart; handleClose: () => 
         <EuiSpacer />
         <EuiModalBody>
           <EuiText size="s">
-            <h2>Roles ({roles.length})</h2>
+            <h2>
+              {i18n.translate('security.account.roles.title', {
+                defaultMessage: 'Roles ({count})',
+                values: { count: roles.length },
+              })}
+            </h2>
           </EuiText>
           <EuiText color="subdued" size="s">
-            Roles you are currently mapped to by your administrator.
+            {i18n.translate('security.account.roles.description', {
+              defaultMessage: 'Roles you are currently mapped to by your administrator.',
+            })}
           </EuiText>
           <EuiSpacer />
           {roles.map((item) => (
@@ -62,10 +70,18 @@ export function RoleInfoPanel(props: { coreStart: CoreStart; handleClose: () => 
           ))}
           <EuiHorizontalRule />
           <EuiText size="s">
-            <h2>Backend roles ({backendRoles.length})</h2>
+            <h2>
+              {i18n.translate('security.account.backendRoles.title', {
+                defaultMessage: 'Backend roles ({count})',
+                values: { count: backendRoles.length },
+              })}
+            </h2>
           </EuiText>
           <EuiText color="subdued" size="s">
-            Backend roles you are currently mapped to by your administrator.
+            {i18n.translate('security.account.backendRoles.description', {
+              defaultMessage:
+                'Backend roles you are currently mapped to by your administrator.',
+            })}
           </EuiText>
           <EuiSpacer />
           {backendRoles.map((item) => (

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -27,6 +27,7 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { keys } from 'lodash';
 import React, { useState } from 'react';
@@ -136,11 +137,15 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   const shouldDisableGlobal = !isGlobalEnabled || !tenants.includes(GLOBAL_TENANT_KEY_NAME);
   const getGlobalDisabledInstruction = () => {
     if (!isGlobalEnabled) {
-      return 'Contact the administrator to enable global tenant.';
+      return i18n.translate('security.account.tenant.enableGlobal', {
+        defaultMessage: 'Contact the administrator to enable global tenant.',
+      });
     }
 
     if (!tenants.includes(GLOBAL_TENANT_KEY_NAME)) {
-      return 'Contact the administrator to get access to global tenant.';
+      return i18n.translate('security.account.tenant.accessGlobal', {
+        defaultMessage: 'Contact the administrator to get access to global tenant.',
+      });
     }
   };
 
@@ -148,15 +153,22 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   const shouldDisablePrivate = !isPrivateEnabled || !tenants.includes(username) || readonly;
   const getPrivateDisabledInstruction = () => {
     if (!isPrivateEnabled) {
-      return 'Contact the administrator to enable private tenant.';
+      return i18n.translate('security.account.tenant.enablePrivate', {
+        defaultMessage: 'Contact the administrator to enable private tenant.',
+      });
     }
 
     if (!tenants.includes(username)) {
-      return 'Contact the administrator to get access to private tenant.';
+      return i18n.translate('security.account.tenant.accessPrivate', {
+        defaultMessage: 'Contact the administrator to get access to private tenant.',
+      });
     }
 
     if (readonly) {
-      return 'Your account has read-only privileges only, using the private tenant is not possible.';
+      return i18n.translate('security.account.tenant.privateReadOnly', {
+        defaultMessage:
+          'Your account has read-only privileges only, using the private tenant is not possible.',
+      });
     }
   };
 
@@ -166,9 +178,14 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
       id: GLOBAL_TENANT_RADIO_ID,
       label: (
         <>
-          Global
+          {i18n.translate('security.account.tenant.global', {
+            defaultMessage: 'Global',
+          })}
           <EuiText size="s">
-            The global tenant is shared between every OpenSearch Dashboards user.
+            {i18n.translate('security.account.tenant.globalDescription', {
+              defaultMessage:
+                'The global tenant is shared between every OpenSearch Dashboards user.',
+            })}
           </EuiText>
           {shouldDisableGlobal && <i>{getGlobalDisabledInstruction()}</i>}
           <EuiSpacer />
@@ -180,10 +197,14 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
       id: PRIVATE_TENANT_RADIO_ID,
       label: (
         <>
-          Private
+          {i18n.translate('security.account.tenant.private', {
+            defaultMessage: 'Private',
+          })}
           <EuiText size="s">
-            The private tenant is exclusive to each user and can&apos;t be shared. You might use the
-            private tenant for exploratory work.
+            {i18n.translate('security.account.tenant.privateDescription', {
+              defaultMessage:
+                "The private tenant is exclusive to each user and can't be shared. You might use the private tenant for exploratory work.",
+            })}
           </EuiText>
           {shouldDisablePrivate && <i>{getPrivateDisabledInstruction()}</i>}
           <EuiSpacer />
@@ -193,7 +214,13 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
     },
     {
       id: CUSTOM_TENANT_RADIO_ID,
-      label: <>Choose from custom</>,
+      label: (
+        <>
+          {i18n.translate('security.account.tenant.chooseCustom', {
+            defaultMessage: 'Choose from custom',
+          })}
+        </>
+      ),
       disabled: customTenantOptions.length === 0,
     },
   ];
@@ -225,7 +252,11 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
 
     // check tenant name before calling backend
     if (tenantName === undefined) {
-      setErrorCallOut('No target tenant is specified!');
+      setErrorCallOut(
+        i18n.translate('security.account.tenant.noTarget', {
+          defaultMessage: 'No target tenant is specified!',
+        })
+      );
     } else {
       try {
         setSavedTenant(tenantName);
@@ -233,7 +264,14 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         await changeTenant(tenantName);
         props.handleSwitchAndClose();
       } catch (e) {
-        setErrorCallOut(constructErrorMessageAndLog(e, 'Failed to switch tenant.'));
+        setErrorCallOut(
+          constructErrorMessageAndLog(
+            e,
+            i18n.translate('security.account.tenant.switchFailed', {
+              defaultMessage: 'Failed to switch tenant.',
+            })
+          )
+        );
       }
     }
   };
@@ -258,7 +296,9 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
           In current EUI if put into the child of radio option, clicking in the combo box will not
           show the drop down list since the radio option consumes the click event. */}
         <EuiCompressedComboBox
-          placeholder="Select a custom tenant"
+          placeholder={i18n.translate('security.account.tenant.selectCustom', {
+            defaultMessage: 'Select a custom tenant',
+          })}
           options={customTenantOptions}
           singleSelection={{ asPlainText: true }}
           selectedOptions={selectedCustomTenantOption}
@@ -277,7 +317,13 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
       </>
     );
   } else {
-    content = <>Contact the administrator to enable multi tenancy.</>;
+    content = (
+      <>
+        {i18n.translate('security.account.tenant.enableMultiTenancy', {
+          defaultMessage: 'Contact the administrator to enable multi tenancy.',
+        })}
+      </>
+    );
   }
 
   return (
@@ -286,14 +332,20 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         <EuiSpacer />
         <EuiModalBody>
           <EuiText size="s">
-            <h2>Select your tenant</h2>
+            <h2>
+              {i18n.translate('security.account.tenant.selectTitle', {
+                defaultMessage: 'Select your tenant',
+              })}
+            </h2>
           </EuiText>
 
           <EuiSpacer />
 
           <EuiText size="s" color="subdued">
-            Tenants are useful for safely sharing your work with other OpenSearch Dashboards users.
-            You can switch your tenant anytime by clicking the user avatar on top right.
+            {i18n.translate('security.account.tenant.intro', {
+              defaultMessage:
+                'Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can switch your tenant anytime by clicking the user avatar on top right.',
+            })}
           </EuiText>
 
           <EuiSpacer />
@@ -303,7 +355,11 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
           <EuiSpacer />
         </EuiModalBody>
         <EuiModalFooter>
-          <EuiSmallButtonEmpty onClick={props.handleClose}>Cancel</EuiSmallButtonEmpty>
+          <EuiSmallButtonEmpty onClick={props.handleClose}>
+            {i18n.translate('security.account.tenant.cancel', {
+              defaultMessage: 'Cancel',
+            })}
+          </EuiSmallButtonEmpty>
 
           <EuiSmallButton
             data-test-subj="confirm"
@@ -311,7 +367,9 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
             disabled={!isMultiTenancyEnabled || invalidCustomTenant}
             onClick={handleTenantConfirmation}
           >
-            Confirm
+            {i18n.translate('security.account.tenant.confirm', {
+              defaultMessage: 'Confirm',
+            })}
           </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -27,6 +27,7 @@ import {
   EuiGlobalToastList,
 } from '@elastic/eui';
 import React, { useContext } from 'react';
+import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { AppDependencies } from '../../types';
 import { buildHashUrl } from '../utils/url-builder';
@@ -42,16 +43,22 @@ import { getClusterInfo } from '../../../utils/datasource-utils';
 import { PageHeader } from '../header/header-components';
 
 const addBackendStep = {
-  title: 'Add backends',
+  title: i18n.translate('security.getStarted.addBackends.title', {
+    defaultMessage: 'Add backends',
+  }),
   children: (
     <>
       <EuiText size="s" color="subdued">
-        Add authentication<EuiCode>(authc)</EuiCode>and authorization<EuiCode>(authz)</EuiCode>
-        information to<EuiCode>config/opensearch-security/config.yml</EuiCode>. The
-        <EuiCode>authc</EuiCode> section contains the backends to check user credentials against.
-        The <EuiCode>authz</EuiCode>
-        section contains any backends to fetch backend roles from. The most common example of a
-        backend role is an LDAP group. <ExternalLink href={DocLinks.AuthenticationFlowDoc} />
+        <FormattedMessage
+          id="security.getStarted.addBackends.body"
+          defaultMessage="Add authentication {authc} and authorization {authz} information to {configFile}. The {authc} section contains the backends to check user credentials against. The {authz} section contains any backends to fetch backend roles from. The most common example of a backend role is an LDAP group."
+          values={{
+            authc: <EuiCode>(authc)</EuiCode>,
+            authz: <EuiCode>(authz)</EuiCode>,
+            configFile: <EuiCode>config/opensearch-security/config.yml</EuiCode>,
+          }}
+        />{' '}
+        <ExternalLink href={DocLinks.AuthenticationFlowDoc} />
       </EuiText>
 
       <EuiSpacer size="m" />
@@ -61,7 +68,9 @@ const addBackendStep = {
           <ExternalLinkButton
             fill
             href={DocLinks.BackendConfigurationDoc}
-            text="Config.yml documentation"
+            text={i18n.translate('security.getStarted.addBackends.configDocs', {
+              defaultMessage: 'Config.yml documentation',
+            })}
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
@@ -71,7 +80,9 @@ const addBackendStep = {
               window.location.href = buildHashUrl(ResourceType.auth);
             }}
           >
-            Review authentication and authorization
+            {i18n.translate('security.getStarted.addBackends.reviewAuth', {
+              defaultMessage: 'Review authentication and authorization',
+            })}
           </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -83,12 +94,16 @@ const addBackendStep = {
 
 const setOfSteps = [
   {
-    title: 'Create roles',
+    title: i18n.translate('security.getStarted.createRoles.title', {
+      defaultMessage: 'Create roles',
+    }),
     children: (
       <>
         <EuiText size="s" color="subdued">
-          Roles are reusable collections of permissions. The default roles are a great starting
-          point, but you might need to create custom roles that meet your exact needs.{' '}
+          {i18n.translate('security.getStarted.createRoles.body', {
+            defaultMessage:
+              'Roles are reusable collections of permissions. The default roles are a great starting point, but you might need to create custom roles that meet your exact needs.',
+          })}{' '}
           <ExternalLink href={DocLinks.CreateRolesDoc} />
         </EuiText>
 
@@ -102,7 +117,9 @@ const setOfSteps = [
                 window.location.href = buildHashUrl(ResourceType.roles);
               }}
             >
-              Explore existing roles
+              {i18n.translate('security.getStarted.createRoles.explore', {
+                defaultMessage: 'Explore existing roles',
+              })}
             </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -112,7 +129,9 @@ const setOfSteps = [
                 window.location.href = buildHashUrl(ResourceType.roles, Action.create);
               }}
             >
-              Create new role
+              {i18n.translate('security.getStarted.createRoles.create', {
+                defaultMessage: 'Create new role',
+              })}
             </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -122,12 +141,16 @@ const setOfSteps = [
     ),
   },
   {
-    title: 'Map users',
+    title: i18n.translate('security.getStarted.mapUsers.title', {
+      defaultMessage: 'Map users',
+    }),
     children: (
       <>
         <EuiText size="s" color="subdued">
-          After a user successfully authenticates, the security plugin retrieves that user’s roles.
-          You can map roles directly to users, but you can also map them to backend roles.{' '}
+          {i18n.translate('security.getStarted.mapUsers.body', {
+            defaultMessage:
+              "After a user successfully authenticates, the security plugin retrieves that user's roles. You can map roles directly to users, but you can also map them to backend roles.",
+          })}{' '}
           <ExternalLink href={DocLinks.MapUsersToRolesDoc} />
         </EuiText>
 
@@ -141,7 +164,9 @@ const setOfSteps = [
                 window.location.href = buildHashUrl(ResourceType.users);
               }}
             >
-              Map users to a role
+              {i18n.translate('security.getStarted.mapUsers.map', {
+                defaultMessage: 'Map users to a role',
+              })}
             </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -151,7 +176,9 @@ const setOfSteps = [
                 window.location.href = buildHashUrl(ResourceType.users, Action.create);
               }}
             >
-              Create internal user
+              {i18n.translate('security.getStarted.mapUsers.createUser', {
+                defaultMessage: 'Create internal user',
+              })}
             </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -174,7 +201,9 @@ export function GetStarted(props: AppDependencies) {
 
   const buttonData = [
     {
-      label: 'Open in new window',
+      label: i18n.translate('security.getStarted.openInNewWindow', {
+        defaultMessage: 'Open in new window',
+      }),
       isLoading: false,
       href: buildHashUrl(),
       iconType: 'popout',
@@ -199,19 +228,30 @@ export function GetStarted(props: AppDependencies) {
           fallBackComponent={
             <EuiPageHeader>
               <EuiText size="s">
-                <h1>Get started</h1>
+                <h1>
+                  {i18n.translate('security.getStarted.pageTitle', {
+                    defaultMessage: 'Get started',
+                  })}
+                </h1>
               </EuiText>
-              <ExternalLinkButton text="Open in new window" href={buildHashUrl()} />
+              <ExternalLinkButton
+                text={i18n.translate('security.getStarted.openInNewWindow', {
+                  defaultMessage: 'Open in new window',
+                })}
+                href={buildHashUrl()}
+              />
             </EuiPageHeader>
           }
           resourceType={'getStarted'}
         />
         <EuiPanel paddingSize="l">
           <EuiText size="s" color="subdued">
-            <p>
-              The OpenSearch security plugin lets you define the API calls that users can make and
-              the data they can access. The most basic configuration consists of these steps.
-            </p>
+              <p>
+                {i18n.translate('security.getStarted.intro', {
+                  defaultMessage:
+                    'The OpenSearch security plugin lets you define the API calls that users can make and the data they can access. The most basic configuration consists of these steps.',
+                })}
+              </p>
           </EuiText>
 
           <EuiSpacer size="l" />
@@ -226,7 +266,11 @@ export function GetStarted(props: AppDependencies) {
 
         <EuiPanel paddingSize="l">
           <EuiTitle size="s">
-            <h3>Optional: Configure audit logs</h3>
+            <h3>
+              {i18n.translate('security.getStarted.auditLogs.title', {
+                defaultMessage: 'Optional: Configure audit logs',
+              })}
+            </h3>
           </EuiTitle>
           <EuiText size="s" color="subdued">
             <p>
@@ -242,7 +286,9 @@ export function GetStarted(props: AppDependencies) {
                 window.location.href = buildHashUrl(ResourceType.auditLogging);
               }}
             >
-              Review Audit Log Configuration
+              {i18n.translate('security.getStarted.auditLogs.review', {
+                defaultMessage: 'Review Audit Log Configuration',
+              })}
             </EuiSmallButton>
           </EuiText>
         </EuiPanel>
@@ -251,13 +297,19 @@ export function GetStarted(props: AppDependencies) {
 
         <EuiPanel paddingSize="l">
           <EuiTitle size="s">
-            <h3>Optional: Purge cache</h3>
+            <h3>
+              {i18n.translate('security.getStarted.purgeCache.title', {
+                defaultMessage: 'Optional: Purge cache',
+              })}
+            </h3>
           </EuiTitle>
           <EuiText size="s" color="subdued">
-            <p>
-              By default, the security plugin caches authenticated users, along with their roles and
-              permissions. This option will purge cached users, roles and permissions.
-            </p>
+              <p>
+                {i18n.translate('security.getStarted.purgeCache.body', {
+                  defaultMessage:
+                    'By default, the security plugin caches authenticated users, along with their roles and permissions. This option will purge cached users, roles and permissions.',
+                })}
+              </p>
             <EuiSmallButton
               iconType="refresh"
               data-test-subj="purge-cache"
@@ -270,21 +322,32 @@ export function GetStarted(props: AppDependencies) {
                   addToast(
                     createSuccessToast(
                       'cache-flush-success',
-                      `Cache purge successful ${getClusterInfo(dataSourceEnabled, dataSource)}`,
-                      `Cache purge successful ${getClusterInfo(dataSourceEnabled, dataSource)}`
+                      i18n.translate('security.getStarted.purgeCache.success', {
+                        defaultMessage: 'Cache purge successful {cluster}',
+                        values: { cluster: getClusterInfo(dataSourceEnabled, dataSource) },
+                      }),
+                      i18n.translate('security.getStarted.purgeCache.success', {
+                        defaultMessage: 'Cache purge successful {cluster}',
+                        values: { cluster: getClusterInfo(dataSourceEnabled, dataSource) },
+                      })
                     )
                   );
                 } catch (err) {
                   addToast(
                     createUnknownErrorToast(
                       'cache-flush-failed',
-                      `purge cache ${getClusterInfo(dataSourceEnabled, dataSource)}`
+                      i18n.translate('security.getStarted.purgeCache.failed', {
+                        defaultMessage: 'purge cache {cluster}',
+                        values: { cluster: getClusterInfo(dataSourceEnabled, dataSource) },
+                      })
                     )
                   );
                 }
               }}
             >
-              Purge cache
+              {i18n.translate('security.getStarted.purgeCache.button', {
+                defaultMessage: 'Purge cache',
+              })}
             </EuiSmallButton>
           </EuiText>
         </EuiPanel>
@@ -294,13 +357,18 @@ export function GetStarted(props: AppDependencies) {
         {props.config.multitenancy.enabled ? (
           <EuiPanel paddingSize="l">
             <EuiTitle size="s">
-              <h3>Optional: Multi-tenancy</h3>
+              <h3>
+                {i18n.translate('security.getStarted.multiTenancy.title', {
+                  defaultMessage: 'Optional: Multi-tenancy',
+                })}
+              </h3>
             </EuiTitle>
             <EuiText size="s" color="subdued">
               <p>
-                By default tenancy is activated in Dashboards. Tenants in OpenSearch Dashboards are
-                spaces for saving index patterns, visualizations, dashboards, and other OpenSearch
-                Dashboards objects.
+                {i18n.translate('security.getStarted.multiTenancy.body', {
+                  defaultMessage:
+                    'By default tenancy is activated in Dashboards. Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects.',
+                })}
               </p>
               <EuiFlexGroup gutterSize="s">
                 <EuiFlexItem grow={false}>
@@ -309,7 +377,9 @@ export function GetStarted(props: AppDependencies) {
                       window.location.href = buildHashUrl(ResourceType.tenants);
                     }}
                   >
-                    Manage Multi-tenancy
+                    {i18n.translate('security.getStarted.multiTenancy.manage', {
+                      defaultMessage: 'Manage Multi-tenancy',
+                    })}
                   </EuiSmallButton>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
@@ -318,7 +388,9 @@ export function GetStarted(props: AppDependencies) {
                       window.location.href = buildHashUrl(ResourceType.tenantsConfigureTab);
                     }}
                   >
-                    Configure Multi-tenancy
+                    {i18n.translate('security.getStarted.multiTenancy.configure', {
+                      defaultMessage: 'Configure Multi-tenancy',
+                    })}
                   </EuiSmallButton>
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -26,6 +26,7 @@ import {
   EuiHorizontalRule,
   EuiCompressedFieldPassword,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { CoreStart } from '../../../../../src/core/public';
 import { ClientConfigType } from '../../types';
 import defaultBrandImage from '../../assets/ui/wazuh_logo.svg';
@@ -137,7 +138,11 @@ export function LoginPage(props: LoginPageDeps) {
     } catch (error) {
       console.log(error);
       setloginFailed(true);
-      setloginError('Invalid username or password. Please try again.');
+      setloginError(
+        i18n.translate('security.login.invalidCredentials', {
+          defaultMessage: 'Invalid username or password. Please try again.',
+        })
+      );
       return;
     }
   };
@@ -195,7 +200,9 @@ export function LoginPage(props: LoginPageDeps) {
               <EuiCompressedFieldText
                 data-test-subj="user-name"
                 aria-label="username_input"
-                placeholder="Username"
+                placeholder={i18n.translate('security.login.usernamePlaceholder', {
+                  defaultMessage: 'Username',
+                })}
                 icon="user"
                 onChange={(e) => setUsername(e.target.value)}
                 value={username}
@@ -208,7 +215,9 @@ export function LoginPage(props: LoginPageDeps) {
               <EuiCompressedFieldPassword
                 data-test-subj="password"
                 aria-label="password_input"
-                placeholder="Password"
+                placeholder={i18n.translate('security.login.passwordPlaceholder', {
+                  defaultMessage: 'Password',
+                })}
                 type="dual"
                 onChange={(e) => setPassword(e.target.value)}
                 value={password}
@@ -228,7 +237,9 @@ export function LoginPage(props: LoginPageDeps) {
                 className={props.config.ui.basicauth.login.buttonstyle || 'btn-login'}
                 onClick={handleSubmit}
               >
-                Log in
+                {i18n.translate('security.login.submitButton', {
+                  defaultMessage: 'Log in',
+                })}
               </EuiButton>
             </EuiCompressedFormRow>
           );
@@ -265,7 +276,11 @@ export function LoginPage(props: LoginPageDeps) {
         default: {
           setloginFailed(true);
           setloginError(
-            `Authentication Type: ${authOpts[i]} is not supported for multiple authentication.`
+            i18n.translate('security.login.unsupportedAuthType', {
+              defaultMessage:
+                'Authentication Type: {authType} is not supported for multiple authentication.',
+              values: { authType: authOpts[i] },
+            })
           );
           break;
         }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -47,6 +47,34 @@ import {
 } from '../common';
 import { APP_ID_CUSTOMERROR } from '../common';
 import { setupTopNavButton } from './apps/account/account-app';
+
+const securityAppTitle = i18n.translate('security.app.securityTitle', {
+  defaultMessage: 'Security',
+});
+const getStartedTitle = i18n.translate('security.app.getStartedTitle', {
+  defaultMessage: 'Get started with access control',
+});
+const authTitle = i18n.translate('security.app.authenticationAndAuthorizationTitle', {
+  defaultMessage: 'Authentication and authorization',
+});
+const rolesTitle = i18n.translate('security.app.rolesTitle', {
+  defaultMessage: 'Roles',
+});
+const internalUsersTitle = i18n.translate('security.app.internalUsersTitle', {
+  defaultMessage: 'Internal users',
+});
+const permissionsTitle = i18n.translate('security.app.permissionsTitle', {
+  defaultMessage: 'Permissions',
+});
+const tenantsTitle = i18n.translate('security.app.tenantsTitle', {
+  defaultMessage: 'Tenants',
+});
+const auditLogsTitle = i18n.translate('security.app.auditLogsTitle', {
+  defaultMessage: 'Audit logs',
+});
+const resourceAccessTitle = i18n.translate('security.app.resourceAccessManagementTitle', {
+  defaultMessage: 'Resource Access Management',
+});
 import { fetchAccountInfoSafe } from './apps/account/utils';
 import {
   API_ENDPOINT_PERMISSIONS_INFO,
@@ -94,7 +122,9 @@ const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_OPENS
 
 const dataAccessUsersCategory: AppCategory & { group?: AppCategory } = {
   id: 'dataAccessAndUsers',
-  label: 'Data access and users',
+  label: i18n.translate('security.app.dataAccessAndUsersCategory', {
+    defaultMessage: 'Data access and users',
+  }),
   order: 9000,
   euiIconType: 'managementApp',
 };
@@ -160,7 +190,7 @@ export class SecurityPlugin
     if (mdsEnabled || apiPermission) {
       core.application.register({
         id: PLUGIN_NAME,
-        title: 'Security',
+        title: securityAppTitle,
         order: 9030,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         navLinkStatus: core.chrome.navGroup.getNavGroupEnabled()
@@ -192,7 +222,7 @@ export class SecurityPlugin
       if (core.chrome.navGroup.getNavGroupEnabled()) {
         core.application.register({
           id: PLUGIN_GET_STARTED_APP_ID,
-          title: 'Get started with access control',
+          title: getStartedTitle,
           order: 8040,
           workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
           updater$: this.appStateUpdater,
@@ -202,7 +232,7 @@ export class SecurityPlugin
         });
         core.application.register({
           id: PLUGIN_AUTH_APP_ID,
-          title: 'Authentication and authorization',
+          title: authTitle,
           order: 8040,
           description: i18n.translate('security.authenticationAndAuthorization.description', {
             defaultMessage: 'Set up authentication and authorization sequences.',
@@ -215,7 +245,7 @@ export class SecurityPlugin
         });
         core.application.register({
           id: PLUGIN_ROLES_APP_ID,
-          title: 'Roles',
+          title: rolesTitle,
           order: 8040,
           description: i18n.translate('security.roles.description', {
             defaultMessage: 'Create a set of permissions with specific privileges.',
@@ -228,7 +258,7 @@ export class SecurityPlugin
         });
         core.application.register({
           id: PLUGIN_USERS_APP_ID,
-          title: 'Internal users',
+          title: internalUsersTitle,
           order: 8040,
           description: i18n.translate('security.internalUsers.description', {
             defaultMessage: 'Define users to control access to your data.',
@@ -241,7 +271,7 @@ export class SecurityPlugin
         });
         core.application.register({
           id: PLUGIN_PERMISSIONS_APP_ID,
-          title: 'Permissions',
+          title: permissionsTitle,
           order: 8040,
           description: i18n.translate('security.permissions.description', {
             defaultMessage: 'Controls access to individual actions and action groups.',
@@ -255,7 +285,7 @@ export class SecurityPlugin
         if (config.multitenancy.enabled) {
           core.application.register({
             id: PLUGIN_TENANTS_APP_ID,
-            title: 'Tenants',
+            title: tenantsTitle,
             order: 8040,
             workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
             updater$: this.appStateUpdater,
@@ -266,7 +296,7 @@ export class SecurityPlugin
         }
         core.application.register({
           id: PLUGIN_AUDITLOG_APP_ID,
-          title: 'Audit logs',
+          title: auditLogsTitle,
           order: 8040,
           description: i18n.translate('security.auditLogs.description', {
             defaultMessage: 'Configure audit logging for system access activities.',
@@ -282,7 +312,7 @@ export class SecurityPlugin
         if (resourceSharingEnabled) {
           core.application.register({
             id: PLUGIN_RESOURCE_ACCESS_MANAGEMENT_APP_ID,
-            title: 'Resource Access Management',
+            title: resourceAccessTitle,
             order: 8040,
             description: i18n.translate('security.resourceAccessManagement.description', {
               defaultMessage:
@@ -348,7 +378,7 @@ export class SecurityPlugin
       if (deps.managementOverview) {
         deps.managementOverview.register({
           id: PLUGIN_NAME,
-          title: 'Security',
+          title: securityAppTitle,
           order: 9030,
           description: i18n.translate('security.securityDescription', {
             defaultMessage:
@@ -358,7 +388,7 @@ export class SecurityPlugin
         if (resourceSharingEnabled) {
           deps.managementOverview.register({
             id: PLUGIN_RESOURCE_ACCESS_MANAGEMENT_APP_ID,
-            title: 'Resource Access Management',
+            title: resourceAccessTitle,
             order: 10050,
             description: i18n.translate('security.resourceAccessManagement.description', {
               defaultMessage:
@@ -377,7 +407,7 @@ export class SecurityPlugin
 
     core.application.register({
       id: APP_ID_LOGIN,
-      title: 'Security',
+      title: securityAppTitle,
       chromeless: true,
       appRoute: LOGIN_PAGE_URI,
       mount: async (params: AppMountParameters) => {
@@ -390,7 +420,7 @@ export class SecurityPlugin
 
     core.application.register({
       id: APP_ID_CUSTOMERROR,
-      title: 'Security',
+      title: securityAppTitle,
       chromeless: true,
       appRoute: CUSTOM_ERROR_PAGE_URI,
       mount: async (params: AppMountParameters) => {
@@ -403,7 +433,7 @@ export class SecurityPlugin
     if (resourceSharingEnabled) {
       core.application.register({
         id: APP_ID_RESOURCE_ACCESS_MANAGEMENT,
-        title: 'Resource Access Management',
+        title: resourceAccessTitle,
         workspaceAvailability: WorkspaceAvailability.outsideWorkspace,
         // If nav groups are enabled, hide the legacy nav link (we’ll add it via navGroup below);
         // otherwise, make the classic left-nav link visible.

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -1,0 +1,166 @@
+{
+  "formats": {
+    "number": {
+      "currency": {
+        "style": "currency"
+      },
+      "percent": {
+        "style": "percent"
+      }
+    },
+    "date": {
+      "short": {
+        "month": "numeric",
+        "day": "numeric",
+        "year": "2-digit"
+      },
+      "medium": {
+        "month": "short",
+        "day": "numeric",
+        "year": "numeric"
+      },
+      "long": {
+        "month": "long",
+        "day": "numeric",
+        "year": "numeric"
+      },
+      "full": {
+        "weekday": "long",
+        "month": "long",
+        "day": "numeric",
+        "year": "numeric"
+      }
+    },
+    "time": {
+      "short": {
+        "hour": "numeric",
+        "minute": "numeric"
+      },
+      "medium": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric"
+      },
+      "long": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric",
+        "timeZoneName": "short"
+      },
+      "full": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric",
+        "timeZoneName": "short"
+      }
+    },
+    "relative": {
+      "years": {
+        "units": "year"
+      },
+      "months": {
+        "units": "month"
+      },
+      "days": {
+        "units": "day"
+      },
+      "hours": {
+        "units": "hour"
+      },
+      "minutes": {
+        "units": "minute"
+      },
+      "seconds": {
+        "units": "second"
+      }
+    }
+  },
+  "messages": {
+    "security.login.invalidCredentials": "Invalid username or password. Please try again.",
+    "security.login.passwordPlaceholder": "Password",
+    "security.login.submitButton": "Log in",
+    "security.login.unsupportedAuthType": "Authentication Type: {authType} is not supported for multiple authentication.",
+    "security.login.usernamePlaceholder": "Username",
+    "security.account.logOut": "Log out",
+    "security.account.resetPassword": "Reset password",
+    "security.account.switchTenants": "Switch tenants",
+    "security.account.viewRolesAndIdentities": "View roles and identities",
+    "security.app.securityTitle": "Security",
+    "security.app.getStartedTitle": "Get started with access control",
+    "security.app.authenticationAndAuthorizationTitle": "Authentication and authorization",
+    "security.app.rolesTitle": "Roles",
+    "security.app.internalUsersTitle": "Internal users",
+    "security.app.permissionsTitle": "Permissions",
+    "security.app.tenantsTitle": "Tenants",
+    "security.app.auditLogsTitle": "Audit logs",
+    "security.app.resourceAccessManagementTitle": "Resource Access Management",
+    "security.authenticationAndAuthorization.description": "Set up authentication and authorization sequences.",
+    "security.roles.description": "Create a set of permissions with specific privileges.",
+    "security.internalUsers.description": "Define users to control access to your data.",
+    "security.permissions.description": "Controls access to individual actions and action groups.",
+    "security.auditLogs.description": "Configure audit logging for system access activities.",
+    "security.resourceAccessManagement.description": "Share and manage access to individual resources (detectors, forecasters, etc.).",
+    "security.securityDescription": "Configure how users access data in OpenSearch with authentication, access control and audit logging.",
+    "security.app.dataAccessAndUsersCategory": "Data access and users",
+    "security.account.reset.title": "Reset password for \"{username}\"",
+    "security.account.reset.invalidCurrentPassword": "Invalid current password. {detail}",
+    "security.account.reset.failed": "Failed to reset password.",
+    "security.account.reset.currentPassword": "Current password",
+    "security.account.reset.currentPasswordHelp": "Verify your account by entering your current password.",
+    "security.account.reset.newPassword": "New password",
+    "security.account.reset.reenterPassword": "Re-enter new password",
+    "security.account.reset.reenterPasswordHelp": "The password must be identical to what you entered above.",
+    "security.account.reset.cancel": "Cancel",
+    "security.account.reset.submit": "Reset",
+    "security.account.roles.title": "Roles ({count})",
+    "security.account.roles.description": "Roles you are currently mapped to by your administrator.",
+    "security.account.backendRoles.title": "Backend roles ({count})",
+    "security.account.backendRoles.description": "Backend roles you are currently mapped to by your administrator.",
+    "security.account.tenant.enableGlobal": "Contact the administrator to enable global tenant.",
+    "security.account.tenant.accessGlobal": "Contact the administrator to get access to global tenant.",
+    "security.account.tenant.enablePrivate": "Contact the administrator to enable private tenant.",
+    "security.account.tenant.accessPrivate": "Contact the administrator to get access to private tenant.",
+    "security.account.tenant.privateReadOnly": "Your account has read-only privileges only, using the private tenant is not possible.",
+    "security.account.tenant.global": "Global",
+    "security.account.tenant.globalDescription": "The global tenant is shared between every OpenSearch Dashboards user.",
+    "security.account.tenant.private": "Private",
+    "security.account.tenant.privateDescription": "The private tenant is exclusive to each user and can't be shared. You might use the private tenant for exploratory work.",
+    "security.account.tenant.chooseCustom": "Choose from custom",
+    "security.account.tenant.noTarget": "No target tenant is specified!",
+    "security.account.tenant.switchFailed": "Failed to switch tenant.",
+    "security.account.tenant.selectCustom": "Select a custom tenant",
+    "security.account.tenant.enableMultiTenancy": "Contact the administrator to enable multi tenancy.",
+    "security.account.tenant.selectTitle": "Select your tenant",
+    "security.account.tenant.intro": "Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can switch your tenant anytime by clicking the user avatar on top right.",
+    "security.account.tenant.cancel": "Cancel",
+    "security.account.tenant.confirm": "Confirm",
+    "audit.logs.introduction": "Audit logs let you track user access to your OpenSearch cluster and are useful for compliance purposes.",
+    "audit.logs.storageInstruction": "Configure the output location and storage types in {opensearchCode}. The default storage location is {internalOpenSearchCode}, which stores the logs in an index on this cluster.",
+    "security.getStarted.addBackends.title": "Add backends",
+    "security.getStarted.addBackends.body": "Add authentication {authc} and authorization {authz} information to {configFile}. The {authc} section contains the backends to check user credentials against. The {authz} section contains any backends to fetch backend roles from. The most common example of a backend role is an LDAP group.",
+    "security.getStarted.addBackends.configDocs": "Config.yml documentation",
+    "security.getStarted.addBackends.reviewAuth": "Review authentication and authorization",
+    "security.getStarted.createRoles.title": "Create roles",
+    "security.getStarted.createRoles.body": "Roles are reusable collections of permissions. The default roles are a great starting point, but you might need to create custom roles that meet your exact needs.",
+    "security.getStarted.createRoles.explore": "Explore existing roles",
+    "security.getStarted.createRoles.create": "Create new role",
+    "security.getStarted.mapUsers.title": "Map users",
+    "security.getStarted.mapUsers.body": "After a user successfully authenticates, the security plugin retrieves that user's roles. You can map roles directly to users, but you can also map them to backend roles.",
+    "security.getStarted.mapUsers.map": "Map users to a role",
+    "security.getStarted.mapUsers.createUser": "Create internal user",
+    "security.getStarted.openInNewWindow": "Open in new window",
+    "security.getStarted.pageTitle": "Get started",
+    "security.getStarted.intro": "The OpenSearch security plugin lets you define the API calls that users can make and the data they can access. The most basic configuration consists of these steps.",
+    "security.getStarted.auditLogs.title": "Optional: Configure audit logs",
+    "security.getStarted.auditLogs.review": "Review Audit Log Configuration",
+    "security.getStarted.purgeCache.title": "Optional: Purge cache",
+    "security.getStarted.purgeCache.body": "By default, the security plugin caches authenticated users, along with their roles and permissions. This option will purge cached users, roles and permissions.",
+    "security.getStarted.purgeCache.success": "Cache purge successful {cluster}",
+    "security.getStarted.purgeCache.failed": "purge cache {cluster}",
+    "security.getStarted.purgeCache.button": "Purge cache",
+    "security.getStarted.multiTenancy.title": "Optional: Multi-tenancy",
+    "security.getStarted.multiTenancy.body": "By default tenancy is activated in Dashboards. Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects.",
+    "security.getStarted.multiTenancy.manage": "Manage Multi-tenancy",
+    "security.getStarted.multiTenancy.configure": "Configure Multi-tenancy"
+  }
+}

--- a/translations/ru-RU.json
+++ b/translations/ru-RU.json
@@ -1,0 +1,166 @@
+{
+  "formats": {
+    "number": {
+      "currency": {
+        "style": "currency"
+      },
+      "percent": {
+        "style": "percent"
+      }
+    },
+    "date": {
+      "short": {
+        "month": "numeric",
+        "day": "numeric",
+        "year": "2-digit"
+      },
+      "medium": {
+        "month": "short",
+        "day": "numeric",
+        "year": "numeric"
+      },
+      "long": {
+        "month": "long",
+        "day": "numeric",
+        "year": "numeric"
+      },
+      "full": {
+        "weekday": "long",
+        "month": "long",
+        "day": "numeric",
+        "year": "numeric"
+      }
+    },
+    "time": {
+      "short": {
+        "hour": "numeric",
+        "minute": "numeric"
+      },
+      "medium": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric"
+      },
+      "long": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric",
+        "timeZoneName": "short"
+      },
+      "full": {
+        "hour": "numeric",
+        "minute": "numeric",
+        "second": "numeric",
+        "timeZoneName": "short"
+      }
+    },
+    "relative": {
+      "years": {
+        "units": "year"
+      },
+      "months": {
+        "units": "month"
+      },
+      "days": {
+        "units": "day"
+      },
+      "hours": {
+        "units": "hour"
+      },
+      "minutes": {
+        "units": "minute"
+      },
+      "seconds": {
+        "units": "second"
+      }
+    }
+  },
+  "messages": {
+    "security.login.invalidCredentials": "Неверное имя пользователя или пароль. Попробуйте ещё раз.",
+    "security.login.passwordPlaceholder": "Пароль",
+    "security.login.submitButton": "Войти",
+    "security.login.unsupportedAuthType": "Тип аутентификации {authType} не поддерживается при нескольких методах входа.",
+    "security.login.usernamePlaceholder": "Имя пользователя",
+    "security.account.logOut": "Выйти",
+    "security.account.resetPassword": "Сменить пароль",
+    "security.account.switchTenants": "Сменить тенант",
+    "security.account.viewRolesAndIdentities": "Роли и идентификаторы",
+    "security.app.securityTitle": "Безопасность",
+    "security.app.getStartedTitle": "Начало работы с контролем доступа",
+    "security.app.authenticationAndAuthorizationTitle": "Аутентификация и авторизация",
+    "security.app.rolesTitle": "Роли",
+    "security.app.internalUsersTitle": "Внутренние пользователи",
+    "security.app.permissionsTitle": "Разрешения",
+    "security.app.tenantsTitle": "Тенанты",
+    "security.app.auditLogsTitle": "Журналы аудита",
+    "security.app.resourceAccessManagementTitle": "Управление доступом к ресурсам",
+    "security.authenticationAndAuthorization.description": "Настройка последовательностей аутентификации и авторизации.",
+    "security.roles.description": "Создание набора разрешений с конкретными привилегиями.",
+    "security.internalUsers.description": "Определение пользователей для контроля доступа к данным.",
+    "security.permissions.description": "Управление доступом к отдельным действиям и группам действий.",
+    "security.auditLogs.description": "Настройка журналирования аудита доступа к системе.",
+    "security.resourceAccessManagement.description": "Совместный доступ и управление доступом к отдельным ресурсам (детекторы, прогнозы и т. д.).",
+    "security.securityDescription": "Настройка доступа пользователей к данным OpenSearch: аутентификация, контроль доступа и аудит.",
+    "security.app.dataAccessAndUsersCategory": "Доступ к данным и пользователи",
+    "security.account.reset.title": "Сменить пароль для «{username}»",
+    "security.account.reset.invalidCurrentPassword": "Неверный текущий пароль. {detail}",
+    "security.account.reset.failed": "Не удалось сменить пароль.",
+    "security.account.reset.currentPassword": "Текущий пароль",
+    "security.account.reset.currentPasswordHelp": "Подтвердите учётную запись, введя текущий пароль.",
+    "security.account.reset.newPassword": "Новый пароль",
+    "security.account.reset.reenterPassword": "Повторите новый пароль",
+    "security.account.reset.reenterPasswordHelp": "Пароль должен совпадать с введённым выше.",
+    "security.account.reset.cancel": "Отмена",
+    "security.account.reset.submit": "Сменить",
+    "security.account.roles.title": "Роли ({count})",
+    "security.account.roles.description": "Роли, назначенные вам администратором.",
+    "security.account.backendRoles.title": "Backend-роли ({count})",
+    "security.account.backendRoles.description": "Backend-роли, назначенные вам администратором.",
+    "security.account.tenant.enableGlobal": "Обратитесь к администратору, чтобы включить глобальный тенант.",
+    "security.account.tenant.accessGlobal": "Обратитесь к администратору, чтобы получить доступ к глобальному тенанту.",
+    "security.account.tenant.enablePrivate": "Обратитесь к администратору, чтобы включить личный тенант.",
+    "security.account.tenant.accessPrivate": "Обратитесь к администратору, чтобы получить доступ к личному тенанту.",
+    "security.account.tenant.privateReadOnly": "У вашей учётной записи только права на чтение, личный тенант недоступен.",
+    "security.account.tenant.global": "Глобальный",
+    "security.account.tenant.globalDescription": "Глобальный тенант общий для всех пользователей OpenSearch Dashboards.",
+    "security.account.tenant.private": "Личный",
+    "security.account.tenant.privateDescription": "Личный тенант принадлежит только вам и не может быть общим. Его можно использовать для пробной работы.",
+    "security.account.tenant.chooseCustom": "Выбрать из пользовательских",
+    "security.account.tenant.noTarget": "Целевой тенант не указан.",
+    "security.account.tenant.switchFailed": "Не удалось сменить тенант.",
+    "security.account.tenant.selectCustom": "Выберите пользовательский тенант",
+    "security.account.tenant.enableMultiTenancy": "Обратитесь к администратору, чтобы включить мультитенантность.",
+    "security.account.tenant.selectTitle": "Выберите тенант",
+    "security.account.tenant.intro": "Тенанты позволяют безопасно делиться работой с другими пользователями OpenSearch Dashboards. Сменить тенант можно в любой момент, нажав на аватар пользователя справа сверху.",
+    "security.account.tenant.cancel": "Отмена",
+    "security.account.tenant.confirm": "Подтвердить",
+    "audit.logs.introduction": "Журналы аудита позволяют отслеживать доступ пользователей к кластеру OpenSearch и полезны для соответствия требованиям.",
+    "audit.logs.storageInstruction": "Настройте место вывода и типы хранения в {opensearchCode}. По умолчанию используется {internalOpenSearchCode} — журналы пишутся в индекс этого кластера.",
+    "security.getStarted.addBackends.title": "Добавить backend-ы",
+    "security.getStarted.addBackends.body": "Добавьте сведения об аутентификации {authc} и авторизации {authz} в {configFile}. Раздел {authc} содержит backend-ы для проверки учётных данных. Раздел {authz} — backend-ы, из которых загружаются backend-роли. Самый частый пример backend-роли — группа LDAP.",
+    "security.getStarted.addBackends.configDocs": "Документация config.yml",
+    "security.getStarted.addBackends.reviewAuth": "Просмотреть аутентификацию и авторизацию",
+    "security.getStarted.createRoles.title": "Создать роли",
+    "security.getStarted.createRoles.body": "Роли — это переиспользуемые наборы разрешений. Роли по умолчанию — хорошая отправная точка, но вам могут понадобиться собственные роли под ваши задачи.",
+    "security.getStarted.createRoles.explore": "Просмотреть существующие роли",
+    "security.getStarted.createRoles.create": "Создать роль",
+    "security.getStarted.mapUsers.title": "Сопоставить пользователей",
+    "security.getStarted.mapUsers.body": "После успешной аутентификации плагин безопасности получает роли пользователя. Роли можно сопоставлять напрямую с пользователями или с backend-ролями.",
+    "security.getStarted.mapUsers.map": "Сопоставить пользователей с ролью",
+    "security.getStarted.mapUsers.createUser": "Создать внутреннего пользователя",
+    "security.getStarted.openInNewWindow": "Открыть в новом окне",
+    "security.getStarted.pageTitle": "Начало работы",
+    "security.getStarted.intro": "Плагин безопасности OpenSearch позволяет задать, какие вызовы API могут делать пользователи и к каким данным они имеют доступ. Базовая настройка состоит из этих шагов.",
+    "security.getStarted.auditLogs.title": "Необязательно: журналы аудита",
+    "security.getStarted.auditLogs.review": "Просмотреть конфигурацию журнала аудита",
+    "security.getStarted.purgeCache.title": "Необязательно: очистить кэш",
+    "security.getStarted.purgeCache.body": "По умолчанию плагин безопасности кэширует аутентифицированных пользователей вместе с их ролями и разрешениями. Эта операция очищает кэш пользователей, ролей и разрешений.",
+    "security.getStarted.purgeCache.success": "Кэш успешно очищен {cluster}",
+    "security.getStarted.purgeCache.failed": "очистка кэша {cluster}",
+    "security.getStarted.purgeCache.button": "Очистить кэш",
+    "security.getStarted.multiTenancy.title": "Необязательно: мультитенантность",
+    "security.getStarted.multiTenancy.body": "По умолчанию тенантность в Dashboards включена. Тенанты в OpenSearch Dashboards — это пространства для шаблонов индексов, визуализаций, панелей мониторинга и других объектов.",
+    "security.getStarted.multiTenancy.manage": "Управление мультитенантностью",
+    "security.getStarted.multiTenancy.configure": "Настройка мультитенантности"
+  }
+}


### PR DESCRIPTION
## Description

Adds Russian (`ru-RU`) i18n catalogs and wraps user-visible strings that were hardcoded in English:

- Login page
- Account menu (roles, reset password, switch tenant, log out)
- Security plugin nav titles
- Get started page

This follows the same approach as other OpenSearch Dashboards plugins: `i18n.translate` / `FormattedMessage` plus `translations/en-US.json` and `translations/ru-RU.json`. Configuration CRUD screens (roles, users, tenants, audit logging settings) are still hardcoded and can follow in a later PR.

## Changes

| Area | What |
| --- | --- |
| `.i18nrc.json` | Registers `translations/en-US.json` and `translations/ru-RU.json` |
| `translations/` | 86 keys, EN + RU |
| `public/plugin.ts` | App and category titles |
| `public/apps/login/` | Login form |
| `public/apps/account/` | Account popover and related modals |
| `public/apps/configuration/panels/get-started.tsx` | Get started copy and actions |

Placeholders (`{username}`, `{count}`, `{cluster}`, `{authc}`, …) are unchanged.

## Test

1. Build/run this plugin against Wazuh dashboard.
2. Set `i18n.locale: ru-RU` in `opensearch_dashboards.yml`.
3. Confirm the login form, account menu, Security nav labels, and Get started page are in Russian.
4. Confirm English still appears when the locale is `en-US`.

## Check List

- [ ] All tests pass
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff


Made with [Cursor](https://cursor.com)