### PR TITLE
Pin Cypress in the E2E jobs

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -18,7 +18,7 @@ inputs:
   resource_sharing_enabled:
     description: 'Resource sharing feature flag'
     required: false
-    default: "false"
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -111,5 +111,7 @@ runs:
         attempt_delay: 2000
         command: |
           cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
-          yarn add cypress --save-dev
+          # Wazuh: pin Cypress. 16.0.0 removed `Cypress.env()`, which the specs
+          # in test/cypress use, so an unpinned install breaks every E2E job.
+          yarn add cypress@15.21.1 --save-dev
           eval ${{ inputs.yarn_command }}

--- a/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
@@ -183,5 +183,7 @@ jobs:
           attempt_delay: 2000
           command: |
             cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
-            yarn add cypress --save-dev
+            # Wazuh: pin Cypress. 16.0.0 removed `Cypress.env()`, which the specs
+            # in test/cypress use, so an unpinned install breaks every E2E job.
+            yarn add cypress@15.21.1 --save-dev
             eval 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/resource-sharing/resource_access_management.spec.ts"'


### PR DESCRIPTION
## Description

Every Cypress E2E job in this repository has been red since 2026-09-01, on every branch, including branches that touch nothing related (`4.10.5`, `change/728-bump-revision`). This pins the Cypress version the jobs install.

## Proposed Changes

`.github/actions/run-cypress-tests/action.yml` installed Cypress with no version:

```yaml
        command: |
          cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
          yarn add cypress --save-dev
          eval ${{ inputs.yarn_command }}
```

Cypress **16.0.0 was published on 2026-09-01 at 14:33 UTC** and removed `Cypress.env()`. The specs call it at import time (`test/cypress/support/constants.js:30-35`), so every spec dies before the first test:

```
CypressError: The following error originated from your test code, not from Cypress.
  > `Cypress.env()` was removed in Cypress version 16.0.0. Please update to use
    `Cypress.expose()` for non-sensitive values, or `cy.env()` for sensitive values.
The key being accessed was: `adminUserName`
  at ./test/cypress/support/constants.js:31:20
0 passing, 1 failing
```

Pinned to `cypress@15.21.1` in the two places that install it — the shared action and `cypress-test-resource-sharing-enabled-e2e.yml`, which repeats the install. 15.21.1 is the version the last green run used (2026-08-31 19:33 UTC, `└─ cypress@15.21.1` in its log).

An exact version rather than a range: `^15.21.1` would pick up a future 15.x, and that drift is what broke the jobs.

### Results and Evidence

Fixes these six checks, red on every branch today: SAML (×2, with and without base path), SAML multi-auth (×2), OIDC (×2), multi datasources enabled, multi datasources disabled, and Resource Access Management.

`cypress-test-tenancy-disabled.yml` and `cypress-test.yml` also install Cypress unpinned, but inside a clone of `opensearch-dashboards-functional-test`, running that repository's specs. The "Cypress Tests Multitenancy Disabled" check passes, so that path does not reach the removed API and is left alone.

Left alone on purpose:

- `package.json` still declares `"cypress": "^13.6.0"` (lockfile 13.17.0). The unpinned install had been overriding it in CI all along, so CI has been running 15.x, not 13.x. Aligning the dependency is a separate decision; pinning to 13.x here would be a version no CI run has ever exercised.
- Migrating the 23 `Cypress.env()` call sites to the Cypress 16 API (`Cypress.expose()` / `cy.env()`) and upgrading the dependency. That is a real migration and it is not needed to get CI green. Note that upstream `opensearch-project/security-dashboards-plugin` has the same unpinned line on `main`, so upstream is broken the same way and has not migrated either.

Prettier also normalized one quoted default in the action file, which it now checks because the file is part of the diff.

### Artifacts Affected

None. CI configuration only.
